### PR TITLE
[SPARK-40746][INFRA] Switch to`pull_request_target` and fix workflow

### DIFF
--- a/.github/workflows/build_3.3.0.yaml
+++ b/.github/workflows/build_3.3.0.yaml
@@ -20,15 +20,18 @@
 name: "Build and Test (3.3.0)"
 
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - 'master'
     paths:
-      - '3.3.0/'
+      - '3.3.0/**'
+      - '.github/workflows/build_3.3.0.yaml'
       - '.github/workflows/main.yml'
 
 jobs:
   run-build:
+    permissions:
+      packages: write
     name: Run
     secrets: inherit
     uses: ./.github/workflows/main.yml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,6 +41,8 @@ on:
 jobs:
   main:
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
     strategy:
       matrix:
         spark_version:
@@ -70,7 +72,9 @@ jobs:
       - name: Generate tags
         run: |
           TAG=scala${{ matrix.scala_version }}-java${{ matrix.java_version }}-${{ matrix.image_suffix }}
-
+          # The pull_request_target job:
+          # 1. Use the `apache` in apache repo (push/pr).
+          # 2. Use the fork repo owner in fork repo PR.
           REPO_OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
           TEST_REPO=ghcr.io/$REPO_OWNER/spark-docker
           IMAGE_NAME=spark
@@ -98,7 +102,7 @@ jobs:
         with:
           context: ${{ env.IMAGE_PATH }}
           push: true
-          tags: ${{ env.TEST_REPO }}:${{ env.UNIQUE_IMAGE_TAG }}
+          tags: ${{ env.TEST_REPO }}/${{ env.IMAGE_NAME }}:${{ env.UNIQUE_IMAGE_TAG }}
           platforms: linux/amd64,linux/arm64
 
       - name: Image digest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Generate tags
         run: |
           TAG=scala${{ matrix.scala_version }}-java${{ matrix.java_version }}-${{ matrix.image_suffix }}
-          # The pull_request_target job:
+          # The pull_request_target event leads to:
           # 1. Use the `apache` in apache repo (push/pr).
           # 2. Use the fork repo owner in fork repo PR.
           REPO_OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')


### PR DESCRIPTION
### What changes were proposed in this pull request?
This patch is to make the workflow work in apache repo:
- Swtich event from `pull_request` to `pull_request_target` to make sure PR has permision to push test image to `ghcr.io/apache/spark-docker/spark:TAG`. This real push image will help us do K8s E2E test in future.
- Add `.github/workflows/build_3.3.0.yaml` and `3.3.0/**` to trigger paths
- Add packages write permissions
- Change `apache/spark-docker:TAG` to `ghcr.io/apache/spark-docker/spark:TAG`



### Why are the changes needed?
To make the workflow works well in apache repo.

- Just like spark main repo we are also using `pull_request_target` help us ensure the permission of PR: https://github.com/apache/spark/search?q=pull_request_target
- ASF also allow it: https://infra.apache.org/github-actions-policy.html
- See also: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
The CI will only work after this patch merged, it won't be triggered in this PR (due to `pull_request_target`)

We can't do complete test before this merge but:
- Test the `pull_request_target` with @martin-g to simulate the behavior of external contributors contributing to the main repository: https://github.com/Yikun/spark-docker/pull/2
- Local repo test to ensure workflow is right: https://github.com/Yikun/spark-docker/pull/3 
