### PR TITLE
[SPARK-40746][INFRA] Fix Dockerfile build workflow

### DIFF
--- a/.github/workflows/build_3.3.0.yaml
+++ b/.github/workflows/build_3.3.0.yaml
@@ -24,7 +24,8 @@ on:
     branches:
       - 'master'
     paths:
-      - '3.3.0/'
+      - '3.3.0/**'
+      - '.github/workflows/build_3.3.0.yaml'
       - '.github/workflows/main.yml'
 
 jobs:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -97,8 +97,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: ${{ env.IMAGE_PATH }}
-          push: true
-          tags: ${{ env.TEST_REPO }}:${{ env.UNIQUE_IMAGE_TAG }}
+          tags: ${{ env.TEST_REPO }}/${{ env.IMAGE_NAME }}:${{ env.UNIQUE_IMAGE_TAG }}
           platforms: linux/amd64,linux/arm64
 
       - name: Image digest


### PR DESCRIPTION
### What changes were proposed in this pull request?
This patch is to make the workflow work in apache repo:
- Add `.github/workflows/build_3.3.0.yaml` and `3.3.0/**` to trigger paths
- Change `apache/spark-docker:TAG` to `ghcr.io/apache/spark-docker/spark:TAG`
- Remove the push, we only need to build locally to validate dockerfile, even in future K8s IT test we can also refactor to use minikube docker, it still can be local build.

### Why are the changes needed?
To make the workflow works well in apache repo.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
CI passed

Closes: https://github.com/apache/spark-docker/pull/5