### PR TITLE
[SPARK-40805] Use `spark` username in official image

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,7 +49,7 @@ jobs:
           - ${{ inputs.scala }}
         java_version:
           - ${{ inputs.java }}
-        image_suffix: [python3-r-ubuntu]
+        image_suffix: [python3-ubuntu, ubuntu, r-ubuntu, python3-r-ubuntu]
     steps:
       - name: Checkout Spark repository
         uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,7 +49,7 @@ jobs:
           - ${{ inputs.scala }}
         java_version:
           - ${{ inputs.java }}
-        image_suffix: [python3-ubuntu, ubuntu, r-ubuntu, python3-r-ubuntu]
+        image_suffix: [python3-r-ubuntu]
     steps:
       - name: Checkout Spark repository
         uses: actions/checkout@v2

--- a/3.3.0/scala2.12-java11-python3-r-ubuntu/Dockerfile
+++ b/3.3.0/scala2.12-java11-python3-r-ubuntu/Dockerfile
@@ -18,10 +18,13 @@ FROM eclipse-temurin:11-jre-focal
 
 ARG spark_uid=185
 
+RUN groupadd --system --gid=${spark_uid} spark && \
+    useradd --system --uid=${spark_uid} --gid=spark spark
+
 RUN set -ex && \
     apt-get update && \
     ln -s /lib /lib64 && \
-    apt install -y gnupg2 wget bash tini libc6 libpam-modules krb5-user libnss3 procps net-tools && \
+    apt install -y gnupg2 wget bash tini libc6 libpam-modules krb5-user libnss3 procps net-tools gosu && \
     apt install -y python3 python3-pip && \
     pip3 install --upgrade pip setuptools && \
     apt install -y r-base r-base-dev && \
@@ -80,5 +83,3 @@ RUN chmod a+x /opt/entrypoint.sh
 
 ENTRYPOINT [ "/opt/entrypoint.sh" ]
 
-# Specify the User that the actual main process will run as
-USER ${spark_uid}

--- a/3.3.0/scala2.12-java11-python3-r-ubuntu/Dockerfile
+++ b/3.3.0/scala2.12-java11-python3-r-ubuntu/Dockerfile
@@ -84,4 +84,3 @@ RUN chmod a+x /opt/decom.sh
 RUN chmod a+x /opt/entrypoint.sh
 
 ENTRYPOINT [ "/opt/entrypoint.sh" ]
-

--- a/3.3.0/scala2.12-java11-python3-r-ubuntu/Dockerfile
+++ b/3.3.0/scala2.12-java11-python3-r-ubuntu/Dockerfile
@@ -33,6 +33,7 @@ RUN set -ex && \
     mkdir -p /opt/spark/examples && \
     mkdir -p /opt/spark/work-dir && \
     touch /opt/spark/RELEASE && \
+    chown -R spark:spark /opt/spark && \
     rm /bin/sh && \
     ln -sv /bin/bash /bin/sh && \
     echo "auth required pam_wheel.so use_uid" >> /etc/pam.d/su && \
@@ -58,6 +59,7 @@ RUN set -ex; \
     rm -rf "$GNUPGHOME" spark.tgz.asc; \
     \
     tar -xf spark.tgz --strip-components=1; \
+    chown -R spark:spark .; \
     mv jars /opt/spark/; \
     mv bin /opt/spark/; \
     mv sbin /opt/spark/; \

--- a/3.3.0/scala2.12-java11-python3-r-ubuntu/entrypoint.sh
+++ b/3.3.0/scala2.12-java11-python3-r-ubuntu/entrypoint.sh
@@ -103,5 +103,13 @@ case "$1" in
     ;;
 esac
 
+switch_spark_if_root() {
+  if [ $(id -u) -ne 0 ]; then
+    return
+  else
+    echo gosu spark
+  fi
+}
+
 # Execute the container CMD under tini for better hygiene
-exec /usr/bin/tini -s -- "${CMD[@]}"
+exec $(switch_spark_if_root) /usr/bin/tini -s -- "${CMD[@]}"

--- a/3.3.0/scala2.12-java11-python3-r-ubuntu/entrypoint.sh
+++ b/3.3.0/scala2.12-java11-python3-r-ubuntu/entrypoint.sh
@@ -103,10 +103,9 @@ case "$1" in
     ;;
 esac
 
+# Switch to spark if no USER specified (root by default) otherwise use USER directly
 switch_spark_if_root() {
-  if [ $(id -u) -ne 0 ]; then
-    return
-  else
+  if [ $(id -u) -eq 0 ]; then
     echo gosu spark
   fi
 }

--- a/3.3.0/scala2.12-java11-python3-ubuntu/Dockerfile
+++ b/3.3.0/scala2.12-java11-python3-ubuntu/Dockerfile
@@ -18,10 +18,13 @@ FROM eclipse-temurin:11-jre-focal
 
 ARG spark_uid=185
 
+RUN groupadd --system --gid=${spark_uid} spark && \
+    useradd --system --uid=${spark_uid} --gid=spark spark
+
 RUN set -ex && \
     apt-get update && \
     ln -s /lib /lib64 && \
-    apt install -y gnupg2 wget bash tini libc6 libpam-modules krb5-user libnss3 procps net-tools && \
+    apt install -y gnupg2 wget bash tini libc6 libpam-modules krb5-user libnss3 procps net-tools gosu && \
     apt install -y python3 python3-pip && \
     pip3 install --upgrade pip setuptools && \
     mkdir -p /opt/spark && \
@@ -29,6 +32,7 @@ RUN set -ex && \
     mkdir -p /opt/spark/examples && \
     mkdir -p /opt/spark/work-dir && \
     touch /opt/spark/RELEASE && \
+    chown -R spark:spark /opt/spark && \
     rm /bin/sh && \
     ln -sv /bin/bash /bin/sh && \
     echo "auth required pam_wheel.so use_uid" >> /etc/pam.d/su && \
@@ -54,6 +58,7 @@ RUN set -ex; \
     rm -rf "$GNUPGHOME" spark.tgz.asc; \
     \
     tar -xf spark.tgz --strip-components=1; \
+    chown -R spark:spark .; \
     mv jars /opt/spark/; \
     mv bin /opt/spark/; \
     mv sbin /opt/spark/; \
@@ -76,6 +81,3 @@ RUN chmod a+x /opt/decom.sh
 RUN chmod a+x /opt/entrypoint.sh
 
 ENTRYPOINT [ "/opt/entrypoint.sh" ]
-
-# Specify the User that the actual main process will run as
-USER ${spark_uid}

--- a/3.3.0/scala2.12-java11-python3-ubuntu/entrypoint.sh
+++ b/3.3.0/scala2.12-java11-python3-ubuntu/entrypoint.sh
@@ -103,5 +103,13 @@ case "$1" in
     ;;
 esac
 
+switch_spark_if_root() {
+  if [ $(id -u) -ne 0 ]; then
+    return
+  else
+    echo gosu spark
+  fi
+}
+
 # Execute the container CMD under tini for better hygiene
-exec /usr/bin/tini -s -- "${CMD[@]}"
+exec $(switch_spark_if_root) /usr/bin/tini -s -- "${CMD[@]}"

--- a/3.3.0/scala2.12-java11-python3-ubuntu/entrypoint.sh
+++ b/3.3.0/scala2.12-java11-python3-ubuntu/entrypoint.sh
@@ -103,10 +103,9 @@ case "$1" in
     ;;
 esac
 
+# Switch to spark if no USER specified (root by default) otherwise use USER directly
 switch_spark_if_root() {
-  if [ $(id -u) -ne 0 ]; then
-    return
-  else
+  if [ $(id -u) -eq 0 ]; then
     echo gosu spark
   fi
 }

--- a/3.3.0/scala2.12-java11-r-ubuntu/Dockerfile
+++ b/3.3.0/scala2.12-java11-r-ubuntu/Dockerfile
@@ -18,15 +18,19 @@ FROM eclipse-temurin:11-jre-focal
 
 ARG spark_uid=185
 
+RUN groupadd --system --gid=${spark_uid} spark && \
+    useradd --system --uid=${spark_uid} --gid=spark spark
+
 RUN set -ex && \
     apt-get update && \
     ln -s /lib /lib64 && \
-    apt install -y gnupg2 wget bash tini libc6 libpam-modules krb5-user libnss3 procps net-tools && \
+    apt install -y gnupg2 wget bash tini libc6 libpam-modules krb5-user libnss3 procps net-tools gosu && \
     apt install -y r-base r-base-dev && \
     mkdir -p /opt/spark && \
     mkdir -p /opt/spark/examples && \
     mkdir -p /opt/spark/work-dir && \
     touch /opt/spark/RELEASE && \
+    chown -R spark:spark /opt/spark && \
     rm /bin/sh && \
     ln -sv /bin/bash /bin/sh && \
     echo "auth required pam_wheel.so use_uid" >> /etc/pam.d/su && \
@@ -52,6 +56,7 @@ RUN set -ex; \
     rm -rf "$GNUPGHOME" spark.tgz.asc; \
     \
     tar -xf spark.tgz --strip-components=1; \
+    chown -R spark:spark .; \
     mv jars /opt/spark/; \
     mv bin /opt/spark/; \
     mv sbin /opt/spark/; \
@@ -74,6 +79,3 @@ RUN chmod a+x /opt/decom.sh
 RUN chmod a+x /opt/entrypoint.sh
 
 ENTRYPOINT [ "/opt/entrypoint.sh" ]
-
-# Specify the User that the actual main process will run as
-USER ${spark_uid}

--- a/3.3.0/scala2.12-java11-r-ubuntu/entrypoint.sh
+++ b/3.3.0/scala2.12-java11-r-ubuntu/entrypoint.sh
@@ -103,5 +103,13 @@ case "$1" in
     ;;
 esac
 
+switch_spark_if_root() {
+  if [ $(id -u) -ne 0 ]; then
+    return
+  else
+    echo gosu spark
+  fi
+}
+
 # Execute the container CMD under tini for better hygiene
-exec /usr/bin/tini -s -- "${CMD[@]}"
+exec $(switch_spark_if_root) /usr/bin/tini -s -- "${CMD[@]}"

--- a/3.3.0/scala2.12-java11-r-ubuntu/entrypoint.sh
+++ b/3.3.0/scala2.12-java11-r-ubuntu/entrypoint.sh
@@ -103,10 +103,9 @@ case "$1" in
     ;;
 esac
 
+# Switch to spark if no USER specified (root by default) otherwise use USER directly
 switch_spark_if_root() {
-  if [ $(id -u) -ne 0 ]; then
-    return
-  else
+  if [ $(id -u) -eq 0 ]; then
     echo gosu spark
   fi
 }

--- a/3.3.0/scala2.12-java11-ubuntu/Dockerfile
+++ b/3.3.0/scala2.12-java11-ubuntu/Dockerfile
@@ -18,14 +18,18 @@ FROM eclipse-temurin:11-jre-focal
 
 ARG spark_uid=185
 
+RUN groupadd --system --gid=${spark_uid} spark && \
+    useradd --system --uid=${spark_uid} --gid=spark spark
+
 RUN set -ex && \
     apt-get update && \
     ln -s /lib /lib64 && \
-    apt install -y gnupg2 wget bash tini libc6 libpam-modules krb5-user libnss3 procps net-tools && \
+    apt install -y gnupg2 wget bash tini libc6 libpam-modules krb5-user libnss3 procps net-tools gosu && \
     mkdir -p /opt/spark && \
     mkdir -p /opt/spark/examples && \
     mkdir -p /opt/spark/work-dir && \
     touch /opt/spark/RELEASE && \
+    chown -R spark:spark /opt/spark && \
     rm /bin/sh && \
     ln -sv /bin/bash /bin/sh && \
     echo "auth required pam_wheel.so use_uid" >> /etc/pam.d/su && \
@@ -51,6 +55,7 @@ RUN set -ex; \
     rm -rf "$GNUPGHOME" spark.tgz.asc; \
     \
     tar -xf spark.tgz --strip-components=1; \
+    chown -R spark:spark .; \
     mv jars /opt/spark/; \
     mv bin /opt/spark/; \
     mv sbin /opt/spark/; \
@@ -71,6 +76,3 @@ RUN chmod a+x /opt/decom.sh
 RUN chmod a+x /opt/entrypoint.sh
 
 ENTRYPOINT [ "/opt/entrypoint.sh" ]
-
-# Specify the User that the actual main process will run as
-USER ${spark_uid}

--- a/3.3.0/scala2.12-java11-ubuntu/entrypoint.sh
+++ b/3.3.0/scala2.12-java11-ubuntu/entrypoint.sh
@@ -103,5 +103,13 @@ case "$1" in
     ;;
 esac
 
+switch_spark_if_root() {
+  if [ $(id -u) -ne 0 ]; then
+    return
+  else
+    echo gosu spark
+  fi
+}
+
 # Execute the container CMD under tini for better hygiene
-exec /usr/bin/tini -s -- "${CMD[@]}"
+exec $(switch_spark_if_root) /usr/bin/tini -s -- "${CMD[@]}"

--- a/3.3.0/scala2.12-java11-ubuntu/entrypoint.sh
+++ b/3.3.0/scala2.12-java11-ubuntu/entrypoint.sh
@@ -103,10 +103,9 @@ case "$1" in
     ;;
 esac
 
+# Switch to spark if no USER specified (root by default) otherwise use USER directly
 switch_spark_if_root() {
-  if [ $(id -u) -ne 0 ]; then
-    return
-  else
+  if [ $(id -u) -eq 0 ]; then
     echo gosu spark
   fi
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This patch:
- Add spark uid/gid in dockerfile (useradd and groupadd). (used in entrypoint) This way is also used by [others DOI](https://github.com/search?p=2&q=org%3Adocker-library+useradd&type=Code) and apache DOI (such as [zookeeper](https://github.com/31z4/zookeeper-docker/blob/master/3.8.0/Dockerfile#L17-L21), [solr](https://github.com/apache/solr-docker/blob/a20477ed123cd1a72132aebcc0742cee46b5f976/9.0/Dockerfile#L108-L110), [flink](https://github.com/apache/flink-docker/blob/master/1.15/scala_2.12-java11-ubuntu/Dockerfile#L55-L56)).
- Use `spark` user in `entrypoint.sh` rather than Dockerfile. (make sure the spark process is executed as non-root users)
- Remove `USER` setting in Dockerfile. (make sure base image has permission to extend dockerifle, such as execute `apt update`)
- Chown script to `spark:spark` instead of `root:root`. (avoid permission issue such like standalone mode)
- Add `gosu` deps, a `sudo` replacement recommanded by [docker](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#user) and [docker official image](https://github.com/docker-library/official-images/blob/9a4d54f1a42ea82970baa4e6f3d0bc75e98fc961/README.md#consistency), and also are used by other DOI images.

This change also follow the rules of docker official images, see also [consistency](https://github.com/docker-library/official-images/blob/9a4d54f1a42ea82970baa4e6f3d0bc75e98fc961/README.md#consistency) and [dockerfile best practices about user](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#user).

### Why are the changes needed?

The below issues are what I have found so far

1. **Irregular login username**
  Docker images username is not very standard, docker run with `185` username is a little bit weird.

  ```
  $ docker run -ti apache/spark bash
  185@d88a24357413:/opt/spark/work-dir$
  ```

2. **Permission issue of spark sbin**
And also there are some permission issue when running some spark script, such as standalone mode:

  ```
  $ docker run -ti apache/spark /opt/spark/sbin/start-master.sh
  
  mkdir: cannot create directory ‘/opt/spark/logs’: Permission denied
  chown: cannot access '/opt/spark/logs': No such file or directory
  starting org.apache.spark.deploy.master.Master, logging to /opt/spark/logs/spark--org.apache.spark.deploy.master.Master-1-1c345a00e312.out
  /opt/spark/sbin/spark-daemon.sh: line 135: /opt/spark/logs/spark--org.apache.spark.deploy.master.Master-1-1c345a00e312.out: No such file or directory
  failed to launch: nice -n 0 /opt/spark/bin/spark-class org.apache.spark.deploy.master.Master --host 1c345a00e312 --port 7077 --webui-port 8080
  tail: cannot open '/opt/spark/logs/spark--org.apache.spark.deploy.master.Master-1-1c345a00e312.out' for reading: No such file or directory
  full log in /opt/spark/logs/spark--org.apache.spark.deploy.master.Master-1-1c345a00e312.out
  ```
  
  </details>

3. **spark as base image case is not supported well**
  Due to static USER set in Dockerfile.
  ```
  $ cat Dockerfile
  FROM apache/spark
  RUN apt update
  
  $  docker build -t spark-test:1015 .
  // ... 
  ------
   > [2/2] RUN apt update:
  #5 0.405 E: Could not open lock file /var/lib/apt/lists/lock - open (13: Permission denied)
  #5 0.405 E: Unable to lock directory /var/lib/apt/lists/
  ------
  executor failed running [/bin/sh -c apt update]: exit code: 100
  
  ```

### Does this PR introduce _any_ user-facing change?
Yes.


### How was this patch tested?
- CI passed: all k8s test

- Regression test:
```
# Username is set to spark rather than 185
docker run -ti spark:scala2.12-java11-python3-r-ubuntu bash
spark@27bbfca0a581:/opt/spark/work-dir$
```
```
# start-master.sh no permission issue
$ docker run -ti spark:scala2.12-java11-python3-r-ubuntu bash

spark@8d1118e26766:~/work-dir$ /opt/spark/sbin/start-master.sh
starting org.apache.spark.deploy.master.Master, logging to /opt/spark/logs/spark--org.apache.spark.deploy.master.Master-1-8d1118e26766.out
```
```
# Image as parent case 
$ cat Dockerfile
FROM spark:scala2.12-java11-python3-r-ubuntu
RUN apt update
$ docker build -t spark-test:1015 .
[+] Building 7.8s (6/6) FINISHED
 => [1/2] FROM docker.io/library/spark:scala2.12-java11-python3-r-ubuntu                                                                                                              0.0s
 => [2/2] RUN apt update                                                                                                                                                              7.7s
```

- Other test:
```
# Test on pyspark
$ cd spark-docker/3.3.0/scala2.12-java11-python3-r-ubuntu
$ docker build -t spark:scala2.12-java11-python3-r-ubuntu .
$ docker run -p 4040:4040 -ti spark:scala2.12-java11-python3-r-ubuntu /opt/spark/bin/pyspark
```

```
# A simple test for `start-master.sh` (standalone mode)
$ docker run -ti spark:scala2.12-java11-python3-r-ubuntu bash
spark@8d1118e26766:~/work-dir$ /opt/spark/sbin/start-master.sh
starting org.apache.spark.deploy.master.Master, logging to /opt/spark/logs/spark--org.apache.spark.deploy.master.Master-1-8d1118e26766.out
```