### PR TITLE
[SPARK-40569] Expose SPARK_MASTER_PORT 7077 for spark standalone cluster

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -156,7 +156,7 @@ jobs:
           key: build-${{ matrix.spark_version }}-scala${{ matrix.scala_version }}-java${{ matrix.java_version }}-coursier
 
       - name : Test - Run spark application for standalone cluster on docker
-        run: testing/run_tests.sh ${TEST_REPO} ${IMAGE_NAME} ${UNIQUE_IMAGE_TAG}
+        run: testing/run_tests.sh ${TEST_REPO} ${IMAGE_NAME} ${UNIQUE_IMAGE_TAG} ${{ matrix.scala_version }}-${{ matrix.spark_version }}
 
       - name: Test - Start minikube
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -155,6 +155,10 @@ jobs:
           path: ~/.cache/coursier
           key: build-${{ matrix.spark_version }}-scala${{ matrix.scala_version }}-java${{ matrix.java_version }}-coursier
 
+      - name : Test - Run spark application for standalone cluster on docker
+        working-directory: ${{ github.workspace }}/spark
+        run: testing/run_tests.sh ${TEST_REPO} ${IMAGE_NAME} ${UNIQUE_IMAGE_TAG}
+
       - name: Test - Start minikube
         run: |
           # See more in "Installation" https://minikube.sigs.k8s.io/docs/start/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -156,7 +156,7 @@ jobs:
           key: build-${{ matrix.spark_version }}-scala${{ matrix.scala_version }}-java${{ matrix.java_version }}-coursier
 
       - name : Test - Run spark application for standalone cluster on docker
-        run: testing/run_tests.sh ${TEST_REPO} ${IMAGE_NAME} ${UNIQUE_IMAGE_TAG} ${{ matrix.scala_version }}-${{ matrix.spark_version }}
+        run: testing/run_tests.sh ${{ matrix.scala_version }}-${{ matrix.spark_version }}
 
       - name: Test - Start minikube
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -156,7 +156,6 @@ jobs:
           key: build-${{ matrix.spark_version }}-scala${{ matrix.scala_version }}-java${{ matrix.java_version }}-coursier
 
       - name : Test - Run spark application for standalone cluster on docker
-        working-directory: ${{ github.workspace }}/spark
         run: testing/run_tests.sh ${TEST_REPO} ${IMAGE_NAME} ${UNIQUE_IMAGE_TAG}
 
       - name: Test - Start minikube

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,9 +60,6 @@ jobs:
           - ${{ inputs.java }}
         image_suffix: [python3-ubuntu, ubuntu, r-ubuntu, python3-r-ubuntu]
     steps:
-      - name : Test - Run spark application for standalone cluster on docker
-        run: testing/run_tests.sh --scala-version ${{ matrix.scala_version }} --spark-version ${{ matrix.spark_version }}
-
       - name: Checkout Spark repository
         uses: actions/checkout@v2
 
@@ -112,6 +109,9 @@ jobs:
           tags: ${{ env.IMAGE_URL }}
           platforms: linux/amd64,linux/arm64
           push: true
+
+      - name : Test - Run spark application for standalone cluster on docker
+        run: testing/run_tests.sh --image-url $IMAGE_URL --scala-version ${{ matrix.scala_version }} --spark-version ${{ matrix.spark_version }}
 
       - name: Test - Checkout Spark repository
         uses: actions/checkout@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,6 +60,9 @@ jobs:
           - ${{ inputs.java }}
         image_suffix: [python3-ubuntu, ubuntu, r-ubuntu, python3-r-ubuntu]
     steps:
+      - name : Test - Run spark application for standalone cluster on docker
+        run: testing/run_tests.sh --scala-version ${{ matrix.scala_version }} --spark-version ${{ matrix.spark_version }}
+
       - name: Checkout Spark repository
         uses: actions/checkout@v2
 
@@ -154,9 +157,6 @@ jobs:
         with:
           path: ~/.cache/coursier
           key: build-${{ matrix.spark_version }}-scala${{ matrix.scala_version }}-java${{ matrix.java_version }}-coursier
-
-      - name : Test - Run spark application for standalone cluster on docker
-        run: testing/run_tests.sh ${{ matrix.scala_version }}-${{ matrix.spark_version }}
 
       - name: Test - Start minikube
         run: |

--- a/3.3.0/scala2.12-java11-python3-r-ubuntu/Dockerfile
+++ b/3.3.0/scala2.12-java11-python3-r-ubuntu/Dockerfile
@@ -83,6 +83,7 @@ RUN chmod g+w /opt/spark/work-dir
 RUN chmod a+x /opt/decom.sh
 RUN chmod a+x /opt/entrypoint.sh
 
+# Expose port for spark master service to listen on
 EXPOSE 7077
 
 ENTRYPOINT [ "/opt/entrypoint.sh" ]

--- a/3.3.0/scala2.12-java11-python3-r-ubuntu/Dockerfile
+++ b/3.3.0/scala2.12-java11-python3-r-ubuntu/Dockerfile
@@ -83,4 +83,6 @@ RUN chmod g+w /opt/spark/work-dir
 RUN chmod a+x /opt/decom.sh
 RUN chmod a+x /opt/entrypoint.sh
 
+EXPOSE 7077
+
 ENTRYPOINT [ "/opt/entrypoint.sh" ]

--- a/3.3.0/scala2.12-java11-python3-ubuntu/Dockerfile
+++ b/3.3.0/scala2.12-java11-python3-ubuntu/Dockerfile
@@ -80,4 +80,6 @@ RUN chmod g+w /opt/spark/work-dir
 RUN chmod a+x /opt/decom.sh
 RUN chmod a+x /opt/entrypoint.sh
 
+EXPOSE 7077
+
 ENTRYPOINT [ "/opt/entrypoint.sh" ]

--- a/3.3.0/scala2.12-java11-python3-ubuntu/Dockerfile
+++ b/3.3.0/scala2.12-java11-python3-ubuntu/Dockerfile
@@ -80,6 +80,7 @@ RUN chmod g+w /opt/spark/work-dir
 RUN chmod a+x /opt/decom.sh
 RUN chmod a+x /opt/entrypoint.sh
 
+# Expose port for spark master service to listen on
 EXPOSE 7077
 
 ENTRYPOINT [ "/opt/entrypoint.sh" ]

--- a/3.3.0/scala2.12-java11-r-ubuntu/Dockerfile
+++ b/3.3.0/scala2.12-java11-r-ubuntu/Dockerfile
@@ -78,4 +78,6 @@ RUN chmod g+w /opt/spark/work-dir
 RUN chmod a+x /opt/decom.sh
 RUN chmod a+x /opt/entrypoint.sh
 
+EXPOSE 7077
+
 ENTRYPOINT [ "/opt/entrypoint.sh" ]

--- a/3.3.0/scala2.12-java11-r-ubuntu/Dockerfile
+++ b/3.3.0/scala2.12-java11-r-ubuntu/Dockerfile
@@ -78,6 +78,7 @@ RUN chmod g+w /opt/spark/work-dir
 RUN chmod a+x /opt/decom.sh
 RUN chmod a+x /opt/entrypoint.sh
 
+# Expose port for spark master service to listen on
 EXPOSE 7077
 
 ENTRYPOINT [ "/opt/entrypoint.sh" ]

--- a/3.3.0/scala2.12-java11-ubuntu/Dockerfile
+++ b/3.3.0/scala2.12-java11-ubuntu/Dockerfile
@@ -75,4 +75,6 @@ RUN chmod g+w /opt/spark/work-dir
 RUN chmod a+x /opt/decom.sh
 RUN chmod a+x /opt/entrypoint.sh
 
+EXPOSE 7077
+
 ENTRYPOINT [ "/opt/entrypoint.sh" ]

--- a/3.3.0/scala2.12-java11-ubuntu/Dockerfile
+++ b/3.3.0/scala2.12-java11-ubuntu/Dockerfile
@@ -75,6 +75,7 @@ RUN chmod g+w /opt/spark/work-dir
 RUN chmod a+x /opt/decom.sh
 RUN chmod a+x /opt/entrypoint.sh
 
+# Expose port for spark master service to listen on
 EXPOSE 7077
 
 ENTRYPOINT [ "/opt/entrypoint.sh" ]

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -95,4 +95,6 @@ RUN chmod g+w /opt/spark/work-dir
 RUN chmod a+x /opt/decom.sh
 RUN chmod a+x /opt/entrypoint.sh
 
+EXPOSE 7077
+
 ENTRYPOINT [ "/opt/entrypoint.sh" ]

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -95,6 +95,7 @@ RUN chmod g+w /opt/spark/work-dir
 RUN chmod a+x /opt/decom.sh
 RUN chmod a+x /opt/entrypoint.sh
 
+# Expose port for spark master service to listen on
 EXPOSE 7077
 
 ENTRYPOINT [ "/opt/entrypoint.sh" ]

--- a/testing/run_tests.sh
+++ b/testing/run_tests.sh
@@ -16,11 +16,34 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+set -exo errexit
+
+SCALA_VERSION="2.12"
+SPARK_VERSION="3.3.0"
+
+# Parse arguments
+while (( "$#" )); do
+  case $1 in
+    --scala-version)
+      SCALA_VERSION="$2"
+      shift
+      ;;
+    --spark-version)
+      SPARK_VERSION="$2"
+      shift
+      ;;
+    *)
+      echo "Unexpected command line flag $2 $1."
+      exit 1
+      ;;
+  esac
+  shift
+done
 
 SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 
 . "${SCRIPT_DIR}/testing.sh"
 
-smoke_test "$1"
+smoke_test
 
 echo "Test successfully finished"

--- a/testing/run_tests.sh
+++ b/testing/run_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash
 
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
@@ -16,34 +16,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-set -exo errexit
-
-SCALA_VERSION="2.12"
-SPARK_VERSION="3.3.0"
-
-# Parse arguments
-while (( "$#" )); do
-  case $1 in
-    --scala-version)
-      SCALA_VERSION="$2"
-      shift
-      ;;
-    --spark-version)
-      SPARK_VERSION="$2"
-      shift
-      ;;
-    *)
-      echo "Unexpected command line flag $2 $1."
-      exit 1
-      ;;
-  esac
-  shift
-done
+set -eo errexit
 
 SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 
 . "${SCRIPT_DIR}/testing.sh"
-
-smoke_test
 
 echo "Test successfully finished"

--- a/testing/run_tests.sh
+++ b/testing/run_tests.sh
@@ -21,6 +21,6 @@ SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 
 . "${SCRIPT_DIR}/testing.sh"
 
-smoke_test "$1" "$2" "$3" "$4"
+smoke_test "$1"
 
 echo "Test successfully finished"

--- a/testing/run_tests.sh
+++ b/testing/run_tests.sh
@@ -1,0 +1,26 @@
+#!/bin/bash -e
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+
+. "${SCRIPT_DIR}/testing.sh"
+
+smoke_test "$1" "$2" "$3"
+
+echo "Test successfully finished"

--- a/testing/run_tests.sh
+++ b/testing/run_tests.sh
@@ -21,6 +21,6 @@ SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 
 . "${SCRIPT_DIR}/testing.sh"
 
-smoke_test "$1" "$2" "$3"
+smoke_test "$1" "$2" "$3" "$4"
 
 echo "Test successfully finished"

--- a/testing/testing.sh
+++ b/testing/testing.sh
@@ -17,6 +17,14 @@
 # limitations under the License.
 #
 
+# This test script runs a simple smoke test in standalone cluster:
+# - create docker network
+# - start up a master
+# - start up a worker
+# - wait for the web UI endpoint to return successfully
+# - run a simple smoke test in standalone cluster
+# - clean up test resource
+
 CURL_TIMEOUT=1
 CURL_COOLDOWN=1
 CURL_MAX_TRIES=30
@@ -25,7 +33,7 @@ NETWORK_NAME=spark-net-bridge
 
 SUBMIT_CONTAINER_NAME=spark-submit
 MASTER_CONTAINER_NAME=spark-master
-WORKER_CONTAINER_NAME=spark-work
+WORKER_CONTAINER_NAME=spark-worker
 SPARK_MASTER_PORT=7077
 SPARK_MASTER_WEBUI_CONTAINER_PORT=8080
 SPARK_MASTER_WEBUI_HOST_PORT=8080
@@ -39,120 +47,118 @@ function create_network() {
 
 # Remove docker network
 function remove_network() {
-    docker network remove "$NETWORK_NAME" > /dev/null
+    docker network rm "$NETWORK_NAME" > /dev/null
 }
 
 # Find and kill any remaining containers attached to the network
 function cleanup() {
-    local containers
-    containers="$(docker ps --quiet --filter network="$NETWORK_NAME")"
+  local containers
+  containers="$(docker ps --quiet --filter network="$NETWORK_NAME")"
 
-    if [ -n "$containers" ]; then
-        echo >&2 -n "==> Killing $(echo -n "$containers" | grep -c '^') orphaned container(s)..."
-        echo "$containers" | xargs docker kill > /dev/null
-        echo >&2 " done."
-    fi
+  if [ -n "$containers" ]; then
+    echo >&2 -n "==> Killing $(echo -n "$containers" | grep -c '^') orphaned container(s)..."
+    echo "$containers" | xargs docker kill > /dev/null
+    echo >&2 " done."
+  fi
 }
 
 function docker_run() {
-    local container_name="$1"
-    local docker_run_command="$2"
-    local args="$3"
+  local container_name="$1"
+  local docker_run_command="$2"
+  local args="$3"
 
-    echo >&2 "===> Starting ${container_name}"
-    if [ "$container_name" = "$MASTER_CONTAINER_NAME" ]; then
-      eval "docker run --rm --detach --network $NETWORK_NAME --name ${container_name} ${docker_run_command} $image_url ${args}"
-    elif [ "$container_name" = "$WORKER_CONTAINER_NAME" ]; then
-      eval "docker run --rm --detach --network $NETWORK_NAME --name ${container_name} ${docker_run_command} $image_url ${args}"
-    else
-      eval "docker run --rm --network $NETWORK_NAME --name ${container_name} ${docker_run_command} $image_url ${args}"
-    fi
+  echo >&2 "===> Starting ${container_name}"
+  if [ "$container_name" = "$MASTER_CONTAINER_NAME" -o "$container_name" = "$WORKER_CONTAINER_NAME" ]; then
+    # --detach: Run spark-master and spark-worker in background, like spark-daemon.sh behaves
+    eval "docker run --rm --detach --network $NETWORK_NAME --name ${container_name} ${docker_run_command} $image_url ${args}"
+  else
+    eval "docker run --rm --network $NETWORK_NAME --name ${container_name} ${docker_run_command} $image_url ${args}"
+  fi
 }
 
 function start_spark_master() {
-    docker_run \
-      "$MASTER_CONTAINER_NAME" \
-      "--publish $SPARK_MASTER_WEBUI_HOST_PORT:$SPARK_MASTER_WEBUI_CONTAINER_PORT $1" \
-      "/opt/spark/bin/spark-class org.apache.spark.deploy.master.Master" > /dev/null
+  docker_run \
+    "$MASTER_CONTAINER_NAME" \
+    "--publish $SPARK_MASTER_WEBUI_HOST_PORT:$SPARK_MASTER_WEBUI_CONTAINER_PORT $1" \
+    "/opt/spark/bin/spark-class org.apache.spark.deploy.master.Master" > /dev/null
 }
 
 function start_spark_worker() {
-    docker_run \
+  docker_run \
     "$WORKER_CONTAINER_NAME" \
     "--publish $SPARK_WORKER_WEBUI_HOST_PORT:$SPARK_WORKER_WEBUI_CONTAINER_PORT $1" \
     "/opt/spark/bin/spark-class org.apache.spark.deploy.worker.Worker spark://$MASTER_CONTAINER_NAME:$SPARK_MASTER_PORT" > /dev/null
 }
 
 function wait_container_ready() {
-    local container_name="$1"
-    local host_port="$2"
-    i=0
-    echo >&2 "===> Waiting for ${container_name} to be ready..."
-    while true; do
-        i=$((i+1))
+  local container_name="$1"
+  local host_port="$2"
+  i=0
+  echo >&2 "===> Waiting for ${container_name} to be ready..."
+  while true; do
+    i=$((i+1))
 
-        set +e
+    set +e
 
-        curl \
-          --silent \
-          --max-time "$CURL_TIMEOUT" \
-          localhost:"${host_port}" \
-          > /dev/null
+    curl \
+      --silent \
+      --max-time "$CURL_TIMEOUT" \
+      localhost:"${host_port}" \
+      > /dev/null
 
-        result=$?
+    result=$?
 
-        set -e
+    set -e
 
-        if [ "$result" -eq 0 ]; then
-            break
-        fi
+    if [ "$result" -eq 0 ]; then
+      break
+    fi
 
-        if [ "$i" -gt "$CURL_MAX_TRIES" ]; then
-            echo >&2 "===> \$CURL_MAX_TRIES exceeded waiting for ${container_name} to be ready"
-            return 1
-        fi
+    if [ "$i" -gt "$CURL_MAX_TRIES" ]; then
+      echo >&2 "===> \$CURL_MAX_TRIES exceeded waiting for ${container_name} to be ready"
+      return 1
+    fi
 
-        sleep "$CURL_COOLDOWN"
-    done
+    sleep "$CURL_COOLDOWN"
+  done
 
-    echo >&2 "===> ${container_name} is ready."
+  echo >&2 "===> ${container_name} is ready."
 }
 
 function run_spark_pi() {
-    docker_run \
-      "$SUBMIT_CONTAINER_NAME" \
-      "$1" \
-      "/opt/spark/bin/spark-submit --master spark://$MASTER_CONTAINER_NAME:$SPARK_MASTER_PORT --class org.apache.spark.examples.SparkPi /opt/spark/examples/jars/spark-examples_${scala_spark_version}.jar 20"
+  docker_run \
+    "$SUBMIT_CONTAINER_NAME" \
+    "$1" \
+    "/opt/spark/bin/spark-submit --master spark://$MASTER_CONTAINER_NAME:$SPARK_MASTER_PORT --class org.apache.spark.examples.SparkPi /opt/spark/examples/jars/spark-examples_$SCALA_VERSION-$SPARK_VERSION.jar 20"
 }
 
-# Run smoke test
-function run_smoke_test() {
-    local docker_run_command=$1
+# Run smoke standalone test
+function run_smoke_test_in_standalone() {
+  local docker_run_command=$1
 
-    create_network
-    cleanup
+  create_network
+  cleanup
 
-    start_spark_master "${docker_run_command}"
-    start_spark_worker "${docker_run_command}"
+  start_spark_master "${docker_run_command}"
+  start_spark_worker "${docker_run_command}"
 
-    wait_container_ready "$MASTER_CONTAINER_NAME" "$SPARK_MASTER_WEBUI_HOST_PORT"
-    wait_container_ready "$WORKER_CONTAINER_NAME" "$SPARK_WORKER_WEBUI_HOST_PORT"
+  wait_container_ready "$MASTER_CONTAINER_NAME" "$SPARK_MASTER_WEBUI_HOST_PORT"
+  wait_container_ready "$WORKER_CONTAINER_NAME" "$SPARK_WORKER_WEBUI_HOST_PORT"
 
-    run_spark_pi "${docker_run_command}"
+  run_spark_pi "${docker_run_command}"
 
-    cleanup
-    remove_network
+  cleanup
+  remove_network
 }
 
-# Run a master and work and verify they start up and connect to each other successfully.
-# And run a Spark Pi to complete smoke test.
+# Run a master and worker and verify they start up and connect to each other successfully.
+# And run a smoke test in standalone cluster.
 function smoke_test() {
-    local scala_spark_version="$1"
-    local image_url=$TEST_REPO/$IMAGE_NAME:$UNIQUE_IMAGE_TAG
+  local image_url=$TEST_REPO/$IMAGE_NAME:$UNIQUE_IMAGE_TAG
 
-    echo >&2 "===> Smoke test for $image_url"
-    run_smoke_test ""
+  echo >&2 "===> Smoke test for $image_url as root"
+  run_smoke_test_in_standalone
 
-    echo >&2 "===> Smoke test for $image_url as non-root"
-    run_smoke_test "--user spark"
+  echo >&2 "===> Smoke test for $image_url as non-root"
+  run_smoke_test_in_standalone "--user spark"
 }

--- a/testing/testing.sh
+++ b/testing/testing.sh
@@ -147,11 +147,8 @@ function run_smoke_test() {
 # Run a master and work and verify they start up and connect to each other successfully.
 # And run a Spark Pi to complete smoke test.
 function smoke_test() {
-    local test_repo="$1"
-    local image_name="$2"
-    local unique_image_tag="$3"
-    local scala_spark_version="$4"
-    local image_url=${test_repo}/${image_name}:${unique_image_tag}
+    local scala_spark_version="$1"
+    local image_url=$TEST_REPO/$IMAGE_NAME:$UNIQUE_IMAGE_TAG
 
     echo >&2 "===> Smoke test for $image_url"
     run_smoke_test ""

--- a/testing/testing.sh
+++ b/testing/testing.sh
@@ -117,7 +117,6 @@ function wait_container_ready() {
     echo >&2 "===> ${container_name} is ready."
 }
 
-# spark-submit
 function run_spark_pi() {
     docker_run \
       "$SUBMIT_CONTAINER_NAME" \
@@ -125,7 +124,7 @@ function run_spark_pi() {
       "/opt/spark/bin/spark-submit --master spark://$MASTER_CONTAINER_NAME:7077 /opt/spark/examples/src/main/python/pi.py 20"
 }
 
-# 总入口
+# Run smoke test
 function run_smoke_test() {
     local docker_run_command=$1
 

--- a/testing/testing.sh
+++ b/testing/testing.sh
@@ -26,6 +26,7 @@ NETWORK_NAME=spark-net-bridge
 SUBMIT_CONTAINER_NAME=spark-submit
 MASTER_CONTAINER_NAME=spark-master
 WORKER_CONTAINER_NAME=spark-work
+SPARK_MASTER_PORT=7077
 SPARK_MASTER_WEBUI_CONTAINER_PORT=8080
 SPARK_MASTER_WEBUI_HOST_PORT=8080
 SPARK_WORKER_WEBUI_CONTAINER_PORT=8081
@@ -79,7 +80,7 @@ function start_spark_worker() {
     docker_run \
     "$WORKER_CONTAINER_NAME" \
     "--publish $SPARK_WORKER_WEBUI_HOST_PORT:$SPARK_WORKER_WEBUI_CONTAINER_PORT $1" \
-    "/opt/spark/bin/spark-class org.apache.spark.deploy.worker.Worker spark://$MASTER_CONTAINER_NAME:7077" > /dev/null
+    "/opt/spark/bin/spark-class org.apache.spark.deploy.worker.Worker spark://$MASTER_CONTAINER_NAME:$SPARK_MASTER_PORT" > /dev/null
 }
 
 function wait_container_ready() {
@@ -121,7 +122,7 @@ function run_spark_pi() {
     docker_run \
       "$SUBMIT_CONTAINER_NAME" \
       "$1" \
-      "/opt/spark/bin/spark-submit --master spark://$MASTER_CONTAINER_NAME:7077 /opt/spark/examples/src/main/python/pi.py 20"
+      "/opt/spark/bin/spark-submit --master spark://$MASTER_CONTAINER_NAME:$SPARK_MASTER_PORT --class org.apache.spark.examples.SparkPi /opt/spark/examples/jars/spark-examples_${scala_spark_version}.jar 20"
 }
 
 # Run smoke test
@@ -149,6 +150,7 @@ function smoke_test() {
     local test_repo="$1"
     local image_name="$2"
     local unique_image_tag="$3"
+    local scala_spark_version="$4"
     local image_url=${test_repo}/${image_name}:${unique_image_tag}
 
     echo >&2 "===> Smoke test for $image_url"

--- a/testing/testing.sh
+++ b/testing/testing.sh
@@ -1,0 +1,160 @@
+#!/bin/bash -e
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+CURL_TIMEOUT=1
+CURL_COOLDOWN=1
+CURL_MAX_TRIES=30
+
+NETWORK_NAME=spark-net-bridge
+
+SUBMIT_CONTAINER_NAME=spark-submit
+MASTER_CONTAINER_NAME=spark-master
+WORKER_CONTAINER_NAME=spark-work
+SPARK_MASTER_WEBUI_CONTAINER_PORT=8080
+SPARK_MASTER_WEBUI_HOST_PORT=8080
+SPARK_WORKER_WEBUI_CONTAINER_PORT=8081
+SPARK_WORKER_WEBUI_HOST_PORT=8081
+
+# Create a new docker bridge network
+function create_network() {
+    docker network create --driver bridge "$NETWORK_NAME" > /dev/null
+}
+
+# Remove docker network
+function remove_network() {
+    docker network remove "$NETWORK_NAME" > /dev/null
+}
+
+# Find and kill any remaining containers attached to the network
+function cleanup() {
+    local containers
+    containers="$(docker ps --quiet --filter network="$NETWORK_NAME")"
+
+    if [ -n "$containers" ]; then
+        echo >&2 -n "==> Killing $(echo -n "$containers" | grep -c '^') orphaned container(s)..."
+        echo "$containers" | xargs docker kill > /dev/null
+        echo >&2 " done."
+    fi
+}
+
+function docker_run() {
+    local container_name="$1"
+    local docker_run_command="$2"
+    local args="$3"
+
+    echo >&2 "===> Starting ${container_name}"
+    if [ "$container_name" = "$MASTER_CONTAINER_NAME" ]; then
+      eval "docker run --rm --detach --network $NETWORK_NAME --name ${container_name} ${docker_run_command} $image_url ${args}"
+    elif [ "$container_name" = "$WORKER_CONTAINER_NAME" ]; then
+      eval "docker run --rm --detach --network $NETWORK_NAME --name ${container_name} ${docker_run_command} $image_url ${args}"
+    else
+      eval "docker run --rm --network $NETWORK_NAME --name ${container_name} ${docker_run_command} $image_url ${args}"
+    fi
+}
+
+function start_spark_master() {
+    docker_run \
+      "$MASTER_CONTAINER_NAME" \
+      "--publish $SPARK_MASTER_WEBUI_HOST_PORT:$SPARK_MASTER_WEBUI_CONTAINER_PORT $1" \
+      "/opt/spark/bin/spark-class org.apache.spark.deploy.master.Master" > /dev/null
+}
+
+function start_spark_worker() {
+    docker_run \
+    "$WORKER_CONTAINER_NAME" \
+    "--publish $SPARK_WORKER_WEBUI_HOST_PORT:$SPARK_WORKER_WEBUI_CONTAINER_PORT $1" \
+    "/opt/spark/bin/spark-class org.apache.spark.deploy.worker.Worker spark://$MASTER_CONTAINER_NAME:7077" > /dev/null
+}
+
+function wait_container_ready() {
+    local container_name="$1"
+    local host_port="$2"
+    i=0
+    echo >&2 "===> Waiting for ${container_name} to be ready..."
+    while true; do
+        i=$((i+1))
+
+        set +e
+
+        curl \
+          --silent \
+          --max-time "$CURL_TIMEOUT" \
+          localhost:"${host_port}" \
+          > /dev/null
+
+        result=$?
+
+        set -e
+
+        if [ "$result" -eq 0 ]; then
+            break
+        fi
+
+        if [ "$i" -gt "$CURL_MAX_TRIES" ]; then
+            echo >&2 "===> \$CURL_MAX_TRIES exceeded waiting for ${container_name} to be ready"
+            return 1
+        fi
+
+        sleep "$CURL_COOLDOWN"
+    done
+
+    echo >&2 "===> ${container_name} is ready."
+}
+
+# spark-submit
+function run_spark_pi() {
+    docker_run \
+      "$SUBMIT_CONTAINER_NAME" \
+      "$1" \
+      "/opt/spark/bin/spark-submit --master spark://$MASTER_CONTAINER_NAME:7077 /opt/spark/examples/src/main/python/pi.py 20"
+}
+
+# 总入口
+function run_smoke_test() {
+    local docker_run_command=$1
+
+    create_network
+    cleanup
+
+    start_spark_master "${docker_run_command}"
+    start_spark_worker "${docker_run_command}"
+
+    wait_container_ready "$MASTER_CONTAINER_NAME" "$SPARK_MASTER_WEBUI_HOST_PORT"
+    wait_container_ready "$WORKER_CONTAINER_NAME" "$SPARK_WORKER_WEBUI_HOST_PORT"
+
+    run_spark_pi "${docker_run_command}"
+
+    cleanup
+    remove_network
+}
+
+# Run a master and work and verify they start up and connect to each other successfully.
+# And run a Spark Pi to complete smoke test.
+function smoke_test() {
+    local test_repo="$1"
+    local image_name="$2"
+    local unique_image_tag="$3"
+    local image_url=${test_repo}/${image_name}:${unique_image_tag}
+
+    echo >&2 "===> Smoke test for $image_url"
+    run_smoke_test ""
+
+    echo >&2 "===> Smoke test for $image_url as non-root"
+    run_smoke_test "--user spark"
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If there is design documentation, please add the link.
  2. If there is a discussion in the mailing list, please add the link.
-->
This PR aims to expose `SPARK_MASTER_PORT` in `Dockerfile`, default value of which is [7077](https://spark.apache.org/docs/latest/security.html#standalone-mode-only).
> The `EXPOSE` instruction informs Docker that the container listens on the specified network ports at runtime. 
https://docs.docker.com/engine/reference/builder/#expose

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you fix a bug, you can clarify why it is a bug.
-->
In standalone mode, spark workers need to connect to spark master through `SPARK_MASTER_PORT`.  It's better to expose default port in DOI.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, expose a new port in Dockerfile.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Add smoke test in GA.