### PR TITLE
[SPARK-40845] Add template support for SPARK_GPG_KEY and fix GPG verify

### DIFF
--- a/3.3.0/scala2.12-java11-python3-r-ubuntu/Dockerfile
+++ b/3.3.0/scala2.12-java11-python3-r-ubuntu/Dockerfile
@@ -52,7 +52,7 @@ RUN set -ex; \
     wget -nv -O spark.tgz "$SPARK_TGZ_URL"; \
     wget -nv -O spark.tgz.asc "$SPARK_TGZ_ASC_URL"; \
     export GNUPGHOME="$(mktemp -d)"; \
-    gpg --keyserver hkps://keyserver.pgp.com --recv-key "$GPG_KEY" || \
+    gpg --keyserver hkps://keys.openpgp.org --recv-key "$GPG_KEY" || \
     gpg --keyserver hkps://keyserver.ubuntu.com --recv-keys "$GPG_KEY"; \
     gpg --batch --verify spark.tgz.asc spark.tgz; \
     gpgconf --kill all; \

--- a/3.3.0/scala2.12-java11-python3-r-ubuntu/Dockerfile
+++ b/3.3.0/scala2.12-java11-python3-r-ubuntu/Dockerfile
@@ -44,7 +44,7 @@ RUN set -ex && \
 # https://downloads.apache.org/spark/KEYS
 ENV SPARK_TGZ_URL=https://dlcdn.apache.org/spark/spark-3.3.0/spark-3.3.0-bin-hadoop3.tgz \
     SPARK_TGZ_ASC_URL=https://downloads.apache.org/spark/spark-3.3.0/spark-3.3.0-bin-hadoop3.tgz.asc \
-    GPG_KEY=E298A3A825C0D65DFD57CBB651716619E084DAB9
+    GPG_KEY=80FB8EBE8EBA68504989703491B5DC815DBF10D3
 
 RUN set -ex; \
     export SPARK_TMP="$(mktemp -d)"; \
@@ -53,7 +53,7 @@ RUN set -ex; \
     wget -nv -O spark.tgz.asc "$SPARK_TGZ_ASC_URL"; \
     export GNUPGHOME="$(mktemp -d)"; \
     gpg --keyserver hkps://keyserver.pgp.com --recv-key "$GPG_KEY" || \
-    gpg --keyserver hkps://keyserver.ubuntu.com --recv-keys "$GPG_KEY" || \
+    gpg --keyserver hkps://keyserver.ubuntu.com --recv-keys "$GPG_KEY"; \
     gpg --batch --verify spark.tgz.asc spark.tgz; \
     gpgconf --kill all; \
     rm -rf "$GNUPGHOME" spark.tgz.asc; \

--- a/3.3.0/scala2.12-java11-python3-ubuntu/Dockerfile
+++ b/3.3.0/scala2.12-java11-python3-ubuntu/Dockerfile
@@ -43,7 +43,7 @@ RUN set -ex && \
 # https://downloads.apache.org/spark/KEYS
 ENV SPARK_TGZ_URL=https://dlcdn.apache.org/spark/spark-3.3.0/spark-3.3.0-bin-hadoop3.tgz \
     SPARK_TGZ_ASC_URL=https://downloads.apache.org/spark/spark-3.3.0/spark-3.3.0-bin-hadoop3.tgz.asc \
-    GPG_KEY=E298A3A825C0D65DFD57CBB651716619E084DAB9
+    GPG_KEY=80FB8EBE8EBA68504989703491B5DC815DBF10D3
 
 RUN set -ex; \
     export SPARK_TMP="$(mktemp -d)"; \
@@ -52,7 +52,7 @@ RUN set -ex; \
     wget -nv -O spark.tgz.asc "$SPARK_TGZ_ASC_URL"; \
     export GNUPGHOME="$(mktemp -d)"; \
     gpg --keyserver hkps://keyserver.pgp.com --recv-key "$GPG_KEY" || \
-    gpg --keyserver hkps://keyserver.ubuntu.com --recv-keys "$GPG_KEY" || \
+    gpg --keyserver hkps://keyserver.ubuntu.com --recv-keys "$GPG_KEY"; \
     gpg --batch --verify spark.tgz.asc spark.tgz; \
     gpgconf --kill all; \
     rm -rf "$GNUPGHOME" spark.tgz.asc; \

--- a/3.3.0/scala2.12-java11-python3-ubuntu/Dockerfile
+++ b/3.3.0/scala2.12-java11-python3-ubuntu/Dockerfile
@@ -51,7 +51,7 @@ RUN set -ex; \
     wget -nv -O spark.tgz "$SPARK_TGZ_URL"; \
     wget -nv -O spark.tgz.asc "$SPARK_TGZ_ASC_URL"; \
     export GNUPGHOME="$(mktemp -d)"; \
-    gpg --keyserver hkps://keyserver.pgp.com --recv-key "$GPG_KEY" || \
+    gpg --keyserver hkps://keys.openpgp.org --recv-key "$GPG_KEY" || \
     gpg --keyserver hkps://keyserver.ubuntu.com --recv-keys "$GPG_KEY"; \
     gpg --batch --verify spark.tgz.asc spark.tgz; \
     gpgconf --kill all; \

--- a/3.3.0/scala2.12-java11-r-ubuntu/Dockerfile
+++ b/3.3.0/scala2.12-java11-r-ubuntu/Dockerfile
@@ -49,7 +49,7 @@ RUN set -ex; \
     wget -nv -O spark.tgz "$SPARK_TGZ_URL"; \
     wget -nv -O spark.tgz.asc "$SPARK_TGZ_ASC_URL"; \
     export GNUPGHOME="$(mktemp -d)"; \
-    gpg --keyserver hkps://keyserver.pgp.com --recv-key "$GPG_KEY" || \
+    gpg --keyserver hkps://keys.openpgp.org --recv-key "$GPG_KEY" || \
     gpg --keyserver hkps://keyserver.ubuntu.com --recv-keys "$GPG_KEY"; \
     gpg --batch --verify spark.tgz.asc spark.tgz; \
     gpgconf --kill all; \

--- a/3.3.0/scala2.12-java11-r-ubuntu/Dockerfile
+++ b/3.3.0/scala2.12-java11-r-ubuntu/Dockerfile
@@ -41,7 +41,7 @@ RUN set -ex && \
 # https://downloads.apache.org/spark/KEYS
 ENV SPARK_TGZ_URL=https://dlcdn.apache.org/spark/spark-3.3.0/spark-3.3.0-bin-hadoop3.tgz \
     SPARK_TGZ_ASC_URL=https://downloads.apache.org/spark/spark-3.3.0/spark-3.3.0-bin-hadoop3.tgz.asc \
-    GPG_KEY=E298A3A825C0D65DFD57CBB651716619E084DAB9
+    GPG_KEY=80FB8EBE8EBA68504989703491B5DC815DBF10D3
 
 RUN set -ex; \
     export SPARK_TMP="$(mktemp -d)"; \
@@ -50,7 +50,7 @@ RUN set -ex; \
     wget -nv -O spark.tgz.asc "$SPARK_TGZ_ASC_URL"; \
     export GNUPGHOME="$(mktemp -d)"; \
     gpg --keyserver hkps://keyserver.pgp.com --recv-key "$GPG_KEY" || \
-    gpg --keyserver hkps://keyserver.ubuntu.com --recv-keys "$GPG_KEY" || \
+    gpg --keyserver hkps://keyserver.ubuntu.com --recv-keys "$GPG_KEY"; \
     gpg --batch --verify spark.tgz.asc spark.tgz; \
     gpgconf --kill all; \
     rm -rf "$GNUPGHOME" spark.tgz.asc; \

--- a/3.3.0/scala2.12-java11-ubuntu/Dockerfile
+++ b/3.3.0/scala2.12-java11-ubuntu/Dockerfile
@@ -40,7 +40,7 @@ RUN set -ex && \
 # https://downloads.apache.org/spark/KEYS
 ENV SPARK_TGZ_URL=https://dlcdn.apache.org/spark/spark-3.3.0/spark-3.3.0-bin-hadoop3.tgz \
     SPARK_TGZ_ASC_URL=https://downloads.apache.org/spark/spark-3.3.0/spark-3.3.0-bin-hadoop3.tgz.asc \
-    GPG_KEY=E298A3A825C0D65DFD57CBB651716619E084DAB9
+    GPG_KEY=80FB8EBE8EBA68504989703491B5DC815DBF10D3
 
 RUN set -ex; \
     export SPARK_TMP="$(mktemp -d)"; \
@@ -49,7 +49,7 @@ RUN set -ex; \
     wget -nv -O spark.tgz.asc "$SPARK_TGZ_ASC_URL"; \
     export GNUPGHOME="$(mktemp -d)"; \
     gpg --keyserver hkps://keyserver.pgp.com --recv-key "$GPG_KEY" || \
-    gpg --keyserver hkps://keyserver.ubuntu.com --recv-keys "$GPG_KEY" || \
+    gpg --keyserver hkps://keyserver.ubuntu.com --recv-keys "$GPG_KEY"; \
     gpg --batch --verify spark.tgz.asc spark.tgz; \
     gpgconf --kill all; \
     rm -rf "$GNUPGHOME" spark.tgz.asc; \

--- a/3.3.0/scala2.12-java11-ubuntu/Dockerfile
+++ b/3.3.0/scala2.12-java11-ubuntu/Dockerfile
@@ -48,7 +48,7 @@ RUN set -ex; \
     wget -nv -O spark.tgz "$SPARK_TGZ_URL"; \
     wget -nv -O spark.tgz.asc "$SPARK_TGZ_ASC_URL"; \
     export GNUPGHOME="$(mktemp -d)"; \
-    gpg --keyserver hkps://keyserver.pgp.com --recv-key "$GPG_KEY" || \
+    gpg --keyserver hkps://keys.openpgp.org --recv-key "$GPG_KEY" || \
     gpg --keyserver hkps://keyserver.ubuntu.com --recv-keys "$GPG_KEY"; \
     gpg --batch --verify spark.tgz.asc spark.tgz; \
     gpgconf --kill all; \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -58,7 +58,7 @@ RUN set -ex; \
     wget -nv -O spark.tgz "$SPARK_TGZ_URL"; \
     wget -nv -O spark.tgz.asc "$SPARK_TGZ_ASC_URL"; \
     export GNUPGHOME="$(mktemp -d)"; \
-    gpg --keyserver hkps://keyserver.pgp.com --recv-key "$GPG_KEY" || \
+    gpg --keyserver hkps://keys.openpgp.org --recv-key "$GPG_KEY" || \
     gpg --keyserver hkps://keyserver.ubuntu.com --recv-keys "$GPG_KEY"; \
     gpg --batch --verify spark.tgz.asc spark.tgz; \
     gpgconf --kill all; \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -50,7 +50,7 @@ RUN set -ex && \
 # https://downloads.apache.org/spark/KEYS
 ENV SPARK_TGZ_URL=https://dlcdn.apache.org/spark/spark-{{ SPARK_VERSION }}/spark-{{ SPARK_VERSION }}-bin-hadoop3.tgz \
     SPARK_TGZ_ASC_URL=https://downloads.apache.org/spark/spark-{{ SPARK_VERSION }}/spark-{{ SPARK_VERSION }}-bin-hadoop3.tgz.asc \
-    GPG_KEY=E298A3A825C0D65DFD57CBB651716619E084DAB9
+    GPG_KEY={{ SPARK_GPG_KEY }}
 
 RUN set -ex; \
     export SPARK_TMP="$(mktemp -d)"; \
@@ -59,7 +59,7 @@ RUN set -ex; \
     wget -nv -O spark.tgz.asc "$SPARK_TGZ_ASC_URL"; \
     export GNUPGHOME="$(mktemp -d)"; \
     gpg --keyserver hkps://keyserver.pgp.com --recv-key "$GPG_KEY" || \
-    gpg --keyserver hkps://keyserver.ubuntu.com --recv-keys "$GPG_KEY" || \
+    gpg --keyserver hkps://keyserver.ubuntu.com --recv-keys "$GPG_KEY"; \
     gpg --batch --verify spark.tgz.asc spark.tgz; \
     gpgconf --kill all; \
     rm -rf "$GNUPGHOME" spark.tgz.asc; \

--- a/tools/template.py
+++ b/tools/template.py
@@ -21,6 +21,11 @@ from argparse import ArgumentParser
 
 from jinja2 import Environment, FileSystemLoader
 
+GPG_KEY_DICT = {
+    # issuer "maxgekk@apache.org"
+    "3.3.0": "80FB8EBE8EBA68504989703491B5DC815DBF10D3",
+}
+
 
 def parse_opts():
     parser = ArgumentParser(prog="template")
@@ -76,6 +81,7 @@ def main():
             HAVE_PY=opts.pyspark,
             HAVE_R=opts.sparkr,
             SPARK_VERSION=opts.spark_version,
+            SPARK_GPG_KEY=GPG_KEY_DICT.get(opts.spark_version),
         )
     )
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
This patch:
- Add template support for `SPARK_GPG_KEY`. 
- Fix a bug on GPG verified. (Change `||` to `;`)
- Use opengpg.org instead of gpg.com becasue it would be uploaded in [spark release process](https://spark.apache.org/release-process.html).

### Why are the changes needed?
Each version have specific GPG key to verified, so we need to set GPG version separately.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
CI passed
Run `./add-dockerfiles.sh 3.3.0` and see GPG set correctly