### PR TITLE
[SPARK-40864] Remove pip/setuptools dynamic upgrade

### DIFF
--- a/3.3.0/scala2.12-java11-python3-r-ubuntu/Dockerfile
+++ b/3.3.0/scala2.12-java11-python3-r-ubuntu/Dockerfile
@@ -26,7 +26,6 @@ RUN set -ex && \
     ln -s /lib /lib64 && \
     apt install -y gnupg2 wget bash tini libc6 libpam-modules krb5-user libnss3 procps net-tools gosu && \
     apt install -y python3 python3-pip && \
-    pip3 install --upgrade pip setuptools && \
     apt install -y r-base r-base-dev && \
     mkdir -p /opt/spark && \
     mkdir /opt/spark/python && \

--- a/3.3.0/scala2.12-java11-python3-ubuntu/Dockerfile
+++ b/3.3.0/scala2.12-java11-python3-ubuntu/Dockerfile
@@ -26,7 +26,6 @@ RUN set -ex && \
     ln -s /lib /lib64 && \
     apt install -y gnupg2 wget bash tini libc6 libpam-modules krb5-user libnss3 procps net-tools gosu && \
     apt install -y python3 python3-pip && \
-    pip3 install --upgrade pip setuptools && \
     mkdir -p /opt/spark && \
     mkdir /opt/spark/python && \
     mkdir -p /opt/spark/examples && \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -27,7 +27,6 @@ RUN set -ex && \
     apt install -y gnupg2 wget bash tini libc6 libpam-modules krb5-user libnss3 procps net-tools gosu && \
     {%- if HAVE_PY %}
     apt install -y python3 python3-pip && \
-    pip3 install --upgrade pip setuptools && \
     {%- endif %}
     {%- if HAVE_R %}
     apt install -y r-base r-base-dev && \


### PR DESCRIPTION
### What changes were proposed in this pull request?
Remove pip/setuptools dynamic upgrade in dockerfile

### Why are the changes needed?
According to [official image suggestion](https://github.com/docker-library/official-images#repeatability), `Rebuilding the same Dockerfile should result in the same version of the image being packaged`.

But we used to upgrade pip/setuptools to latest, actually we don't need a latest pip/setuptools for any reason I can think out. I also take a look on [initial commits](https://github.com/apache-spark-on-k8s/spark/commit/befcf0a30651d0335bb57c242a824e43748db33f) for this line, according merge history no more reason for it.

### Does this PR introduce _any_ user-facing change?
The OS recommand pip/setuptools version is used.

### How was this patch tested?

CI passed.