### PR TITLE
[SPARK-41258][INFRA] Upgrade docker and actions to cleanup warnning

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,7 +71,7 @@ jobs:
         image_suffix: [python3-ubuntu, ubuntu, r-ubuntu, python3-r-ubuntu]
     steps:
       - name: Checkout Spark Docker repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
@@ -122,7 +122,7 @@ jobs:
           echo "PUBLISH_IMAGE_URL:"${PUBLISH_IMAGE_URL}
 
       - name: Build and push test image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: ${{ env.IMAGE_PATH }}
           tags: ${{ env.IMAGE_URL }}
@@ -258,7 +258,7 @@ jobs:
 
       - name: Publish - Push Image
         if: ${{ inputs.publish }}
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: ${{ env.IMAGE_PATH }}
           push: true


### PR DESCRIPTION
### What changes were proposed in this pull request?
- Upgrade `actions/checkout` from v2 to v3
- Upgrade `docker/build-push-action` from v2 to v3


### Why are the changes needed?
Cleanup set output and lower version node warnning


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Test passed