### PR TITLE
[SPARK-41287][INFRA] Add test workflow to help self-build image test in fork repo

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,7 +48,7 @@ on:
         type: boolean
         default: false
       repository:
-        description: The registry to be published/tested. (Avaliable only in publish/test workflow)
+        description: The registry to be published/tested. (Available only in publish/test workflow)
         required: false
         type: string
         default: ghcr.io/apache/spark-docker
@@ -59,7 +59,7 @@ on:
         default: python
       image-tag:
         type: string
-        description: The image tag to be tested. (Avaliable only in test workflow)
+        description: The image tag to be tested. (Available only in test workflow)
         required: false
         default: latest
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,13 +37,18 @@ on:
         required: true
         type: string
         default: 11
+      build:
+        description: Build the image or not.
+        required: false
+        type: boolean
+        default: true
       publish:
         description: Publish the image or not.
         required: false
         type: boolean
         default: false
       repository:
-        description: The registry to be published (Avaliable only when publish is selected).
+        description: The registry to be published/tested. (Avaliable only in publish/test workflow)
         required: false
         type: string
         default: ghcr.io/apache/spark-docker
@@ -52,6 +57,11 @@ on:
         required: false
         type: string
         default: python
+      image-tag:
+        type: string
+        description: The image tag to be tested. (Avaliable only in test workflow)
+        required: false
+        default: latest
 
 jobs:
   main:
@@ -83,11 +93,18 @@ jobs:
           esac
           TAG=scala${{ inputs.scala }}-java${{ inputs.java }}-$SUFFIX
 
-          REPO_OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
-          TEST_REPO=localhost:5000/$REPO_OWNER/spark-docker
           IMAGE_NAME=spark
           IMAGE_PATH=${{ inputs.spark }}/$TAG
-          UNIQUE_IMAGE_TAG=${{ inputs.spark }}-$TAG
+          if [ "${{ inputs.build }}" == "true" ]; then
+            # Use the local registry to build and test
+            REPO_OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+            TEST_REPO=localhost:5000/$REPO_OWNER/spark-docker
+            UNIQUE_IMAGE_TAG=${{ inputs.spark }}-$TAG
+          else
+            # Use specified {repository}/spark:{image-tag} image to test
+            TEST_REPO=${{ inputs.repository }}
+            UNIQUE_IMAGE_TAG=${{ inputs.image-tag }}
+          fi
           IMAGE_URL=$TEST_REPO/$IMAGE_NAME:$UNIQUE_IMAGE_TAG
 
           PUBLISH_REPO=${{ inputs.repository }}
@@ -119,15 +136,18 @@ jobs:
           echo "PUBLISH_IMAGE_URL:"${PUBLISH_IMAGE_URL}
 
       - name: Build - Set up QEMU
+        if: ${{ inputs.build }}
         uses: docker/setup-qemu-action@v2
 
       - name: Build - Set up Docker Buildx
+        if: ${{ inputs.build }}
         uses: docker/setup-buildx-action@v2
         with:
           # This required by local registry
           driver-opts: network=host
 
       - name: Build - Build and push test image
+        if: ${{ inputs.build }}
         uses: docker/build-push-action@v3
         with:
           context: ${{ env.IMAGE_PATH }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,7 +36,7 @@ on:
         type: boolean
         required: true
       repository:
-        description: The registry to be published (Avaliable only when publish is true).
+        description: The registry to be published (Available only when publish is true).
         required: false
         default: ghcr.io/apache/spark-docker
         type: choice

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,76 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: "Test"
+
+on:
+  workflow_dispatch:
+    inputs:
+      spark:
+        description: 'The Spark version of Spark image.'
+        required: true
+        default: '3.3.1'
+        type: choice
+        options:
+        - 3.3.0
+        - 3.3.1
+      java:
+        description: 'The Java version of Spark image.'
+        default: 11
+        type: string
+        required: true
+      scala:
+        description: 'The Scala version of Spark image.'
+        default: 2.12
+        type: string
+        required: true
+      image-type:
+        description: 'The image type of Spark image.'
+        required: true
+        default: 'python'
+        type: choice
+        options:
+        - all
+        - python
+        - scala
+        - r
+      repository:
+        description: The registry to be tested.
+        required: true
+        type: string
+        default: ghcr.io/apache/spark-docker
+      image-tag:
+        description: 'The image tag to be tested.'
+        default: latest
+        type: string
+        required: true
+
+jobs:
+  run-build:
+    name: Test ${{ inputs.repository }}/spark:${{ inputs.image-tag }}
+    secrets: inherit
+    uses: ./.github/workflows/main.yml
+    with:
+      spark: ${{ inputs.spark }}
+      scala: ${{ inputs.scala }}
+      java: ${{ inputs.java }}
+      repository: ${{ inputs.repository }}
+      image-tag: ${{ inputs.image-tag }}
+      image-type: ${{ inputs.image-type }}
+      build: false


### PR DESCRIPTION
### What changes were proposed in this pull request?
This patch adds a test workflow to help fork repo to test image in their fork repos. 

![image](https://user-images.githubusercontent.com/1736354/204183109-e2341397-251e-42a0-b5f7-c1c1f9334ff9.png)

such like:
- https://github.com/Yikun/spark-docker/actions/runs/3552072792/jobs/5966742869
- https://github.com/Yikun/spark-docker/actions/runs/3561513498/jobs/5982485960

### Why are the changes needed?
Help devs/users test their own image in their fork repo


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Test in my fork repo:
https://github.com/Yikun/spark-docker/actions/workflows/test.yml
