### PR TITLE
[SPARK-43806] Add awesome-spark-docker.md

### DIFF
--- a/awesome-spark-docker.md
+++ b/awesome-spark-docker.md
@@ -1,0 +1,7 @@
+A curated list of awesome Apache Spark Docker resources.
+
+- [jupyter/docker-stacks/pyspark-notebook](https://github.com/jupyter/docker-stacks/tree/master/pyspark-notebook) - PySpark with Jupyter Notebook.
+- [big-data-europe/docker-spark](https://github.com/big-data-europe/docker-spark) - The standalone cluster and spark applications related Dockerfiles.
+- [openeuler/spark](https://github.com/openeuler-mirror/openeuler-docker-images/tree/master/spark) - Dockerfile reference for dnf/yum based OS.
+- [GoogleCloudPlatform/spark-on-k8s-operator](https://github.com/GoogleCloudPlatform/spark-on-k8s-operator) - Kubernetes operator for managing the lifecycle of Apache Spark applications on Kubernetes.
+


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add links to more related images and dockerfile reference.

### Why are the changes needed?
Something we talked about in "Spark on Kube Coffe Chats“[1] to add links to more related images and dockerfile reference. Init with [2].
[1] https://lists.apache.org/thread/26gpmlhqhk5cp2fhtzrpl5f61p8jc551
[2] https://github.com/awesome-spark/awesome-spark/blob/main/README.md#docker-images

### Does this PR introduce _any_ user-facing change?
Doc only

### How was this patch tested?
No
