### PR TITLE
[SPARK-43367] Recover sh in dockerfile

### DIFF
--- a/3.4.0/scala2.12-java11-ubuntu/Dockerfile
+++ b/3.4.0/scala2.12-java11-ubuntu/Dockerfile
@@ -32,8 +32,6 @@ RUN set -ex; \
     chmod g+w /opt/spark/work-dir; \
     touch /opt/spark/RELEASE; \
     chown -R spark:spark /opt/spark; \
-    rm /bin/sh; \
-    ln -sv /bin/bash /bin/sh; \
     echo "auth required pam_wheel.so use_uid" >> /etc/pam.d/su; \
     chgrp root /etc/passwd && chmod ug+rw /etc/passwd; \
     rm -rf /var/cache/apt/*; \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -32,8 +32,6 @@ RUN set -ex; \
     chmod g+w /opt/spark/work-dir; \
     touch /opt/spark/RELEASE; \
     chown -R spark:spark /opt/spark; \
-    rm /bin/sh; \
-    ln -sv /bin/bash /bin/sh; \
     echo "auth required pam_wheel.so use_uid" >> /etc/pam.d/su; \
     chgrp root /etc/passwd && chmod ug+rw /etc/passwd; \
     rm -rf /var/cache/apt/*; \


### PR DESCRIPTION
### What changes were proposed in this pull request?
Recover `sh`, we remove `sh` due to https://github.com/apache-spark-on-k8s/spark/pull/444/files#r134075892 , now `SPARK_DRIVER_JAVA_OPTS` related code already move to `entrypoint.sh` with `#!/bin/bash`, so we don't need this hack way.

See also:
[1] https://github.com/docker-library/official-images/pull/13089#issuecomment-1533540388
[2] https://github.com/docker-library/official-images/pull/13089#issuecomment-1561793792


### Why are the changes needed?
Recover sh

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
CI passed
