### PR TITLE
[SPARK-43370] Switch spark user only when run driver and executor

### DIFF
--- a/3.4.0/scala2.12-java11-python3-r-ubuntu/Dockerfile
+++ b/3.4.0/scala2.12-java11-python3-r-ubuntu/Dockerfile
@@ -16,6 +16,8 @@
 #
 FROM spark:3.4.0-scala2.12-java11-ubuntu
 
+USER root
+
 RUN set -ex; \
     apt-get update; \
     apt install -y python3 python3-pip; \
@@ -24,3 +26,5 @@ RUN set -ex; \
     rm -rf /var/lib/apt/lists/*
 
 ENV R_HOME /usr/lib/R
+
+USER spark

--- a/3.4.0/scala2.12-java11-python3-ubuntu/Dockerfile
+++ b/3.4.0/scala2.12-java11-python3-ubuntu/Dockerfile
@@ -16,8 +16,12 @@
 #
 FROM spark:3.4.0-scala2.12-java11-ubuntu
 
+USER root
+
 RUN set -ex; \
     apt-get update; \
     apt install -y python3 python3-pip; \
     rm -rf /var/cache/apt/*; \
     rm -rf /var/lib/apt/lists/*
+
+USER spark

--- a/3.4.0/scala2.12-java11-r-ubuntu/Dockerfile
+++ b/3.4.0/scala2.12-java11-r-ubuntu/Dockerfile
@@ -16,6 +16,8 @@
 #
 FROM spark:3.4.0-scala2.12-java11-ubuntu
 
+USER root
+
 RUN set -ex; \
     apt-get update; \
     apt install -y r-base r-base-dev; \
@@ -23,3 +25,5 @@ RUN set -ex; \
     rm -rf /var/lib/apt/lists/*
 
 ENV R_HOME /usr/lib/R
+
+USER spark

--- a/3.4.0/scala2.12-java11-ubuntu/Dockerfile
+++ b/3.4.0/scala2.12-java11-ubuntu/Dockerfile
@@ -79,4 +79,6 @@ ENV SPARK_HOME /opt/spark
 
 WORKDIR /opt/spark/work-dir
 
+USER spark
+
 ENTRYPOINT [ "/opt/entrypoint.sh" ]

--- a/3.4.0/scala2.12-java11-ubuntu/entrypoint.sh
+++ b/3.4.0/scala2.12-java11-ubuntu/entrypoint.sh
@@ -110,7 +110,6 @@ case "$1" in
 
   *)
     # Non-spark-on-k8s command provided, proceeding in pass-through mode...
-    CMD=("$@")
-    "${CMD[@]}"
+    exec "$@"
     ;;
 esac

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -79,4 +79,6 @@ ENV SPARK_HOME /opt/spark
 
 WORKDIR /opt/spark/work-dir
 
+USER spark
+
 ENTRYPOINT [ "/opt/entrypoint.sh" ]

--- a/entrypoint.sh.template
+++ b/entrypoint.sh.template
@@ -110,7 +110,6 @@ case "$1" in
 
   *)
     # Non-spark-on-k8s command provided, proceeding in pass-through mode...
-    CMD=("$@")
-    "${CMD[@]}"
+    exec "$@"
     ;;
 esac

--- a/r-python.template
+++ b/r-python.template
@@ -16,6 +16,8 @@
 #
 FROM spark:{{ SPARK_VERSION }}-scala{{ SCALA_VERSION }}-java{{ JAVA_VERSION }}-ubuntu
 
+USER root
+
 RUN set -ex; \
     apt-get update; \
     {%- if HAVE_PY %}
@@ -30,3 +32,5 @@ RUN set -ex; \
 
 ENV R_HOME /usr/lib/R
 {%- endif %}
+
+USER spark


### PR DESCRIPTION
### What changes were proposed in this pull request?
Switch spark user only when run driver and executor

### Why are the changes needed?
Address doi comments: question 7 [1]

[1] https://github.com/docker-library/official-images/pull/13089#issuecomment-1533540388 
[2] https://github.com/docker-library/official-images/pull/13089#issuecomment-1561793792


### Does this PR introduce _any_ user-facing change?
Yes

### How was this patch tested?
1. test mannuly
```
cd ~/spark-docker/3.4.0/scala2.12-java11-ubuntu
$ docker build . -t spark-test

$ docker run -ti spark-test bash
spark@afa78af05cf8:/opt/spark/work-dir$

$ docker run  --user root  -ti spark-test bash
root@095e0d7651fd:/opt/spark/work-dir#
```
2. ci passed

Closes: https://github.com/apache/spark-docker/pull/44