### PR TITLE
[SPARK-43368] Use `libnss_wrapper` to fake passwd entry

### DIFF
--- a/3.4.0/scala2.12-java11-ubuntu/Dockerfile
+++ b/3.4.0/scala2.12-java11-ubuntu/Dockerfile
@@ -24,7 +24,7 @@ RUN groupadd --system --gid=${spark_uid} spark && \
 RUN set -ex; \
     apt-get update; \
     ln -s /lib /lib64; \
-    apt install -y gnupg2 wget bash tini libc6 libpam-modules krb5-user libnss3 procps net-tools gosu; \
+    apt install -y gnupg2 wget bash tini libc6 libpam-modules krb5-user libnss3 procps net-tools gosu libnss-wrapper; \
     mkdir -p /opt/spark; \
     mkdir /opt/spark/python; \
     mkdir -p /opt/spark/examples; \
@@ -33,7 +33,6 @@ RUN set -ex; \
     touch /opt/spark/RELEASE; \
     chown -R spark:spark /opt/spark; \
     echo "auth required pam_wheel.so use_uid" >> /etc/pam.d/su; \
-    chgrp root /etc/passwd && chmod ug+rw /etc/passwd; \
     rm -rf /var/cache/apt/*; \
     rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -24,7 +24,7 @@ RUN groupadd --system --gid=${spark_uid} spark && \
 RUN set -ex; \
     apt-get update; \
     ln -s /lib /lib64; \
-    apt install -y gnupg2 wget bash tini libc6 libpam-modules krb5-user libnss3 procps net-tools gosu; \
+    apt install -y gnupg2 wget bash tini libc6 libpam-modules krb5-user libnss3 procps net-tools gosu libnss-wrapper; \
     mkdir -p /opt/spark; \
     mkdir /opt/spark/python; \
     mkdir -p /opt/spark/examples; \
@@ -33,7 +33,6 @@ RUN set -ex; \
     touch /opt/spark/RELEASE; \
     chown -R spark:spark /opt/spark; \
     echo "auth required pam_wheel.so use_uid" >> /etc/pam.d/su; \
-    chgrp root /etc/passwd && chmod ug+rw /etc/passwd; \
     rm -rf /var/cache/apt/*; \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Use `libnss_wrapper` to fake passwd entry instead of changing passwd to resolve random UID problem. And also we only attempt to setup fake passwd entry for driver/executor, but for cmd like `bash`, the fake passwd will not be set.

### Why are the changes needed?
In the past, we add the entry to  `/etc/passwd` directly for current UID, it's mainly for [OpenShift anonymous random `uid` case](https://github.com/docker-library/official-images/pull/13089#issuecomment-1534706523) (See also in https://github.com/apache-spark-on-k8s/spark/pull/404), but this way bring the pontential security issue about widely permision of `/etc/passwd`.

According to DOI reviewer [suggestion](https://github.com/docker-library/official-images/pull/13089#issuecomment-1561793792), we'd better to resolve this problem by using [libnss_wrapper](https://cwrap.org/nss_wrapper.html). It's a library to help set a fake passwd entry by setting `LD_PRELOAD`, `NSS_WRAPPER_PASSWD`, `NSS_WRAPPER_GROUP`. Such as random UID is `1000`, the env will be:

```
spark@6f41b8e5be9b:/opt/spark/work-dir$ id -u
1000
spark@6f41b8e5be9b:/opt/spark/work-dir$ id -g
1000
spark@6f41b8e5be9b:/opt/spark/work-dir$ whoami
spark
spark@6f41b8e5be9b:/opt/spark/work-dir$ echo $LD_PRELOAD
/usr/lib/libnss_wrapper.so
spark@6f41b8e5be9b:/opt/spark/work-dir$ echo $NSS_WRAPPER_PASSWD
/tmp/tmp.r5x4SMX35B
spark@6f41b8e5be9b:/opt/spark/work-dir$ cat /tmp/tmp.r5x4SMX35B
spark:x:1000:1000:${SPARK_USER_NAME:-anonymous uid}:/opt/spark:/bin/false
spark@6f41b8e5be9b:/opt/spark/work-dir$ echo $NSS_WRAPPER_GROUP
/tmp/tmp.XcnnYuD68r
spark@6f41b8e5be9b:/opt/spark/work-dir$ cat /tmp/tmp.XcnnYuD68r
spark:x:1000:
```

### Does this PR introduce _any_ user-facing change?
Yes, setup fake ENV rather than changing `/etc/passwd`.

### How was this patch tested?
#### 1. Without `attempt_setup_fake_passwd_entry`, the user is `I have no name!`
```
# docker run -it --rm --user 1000:1000  spark-test bash
groups: cannot find name for group ID 1000
I have no name!@998110cd5a26:/opt/spark/work-dir$
I have no name!@0fea1d27d67d:/opt/spark/work-dir$ id -u
1000
I have no name!@0fea1d27d67d:/opt/spark/work-dir$ id -g
1000
I have no name!@0fea1d27d67d:/opt/spark/work-dir$ whoami
whoami: cannot find name for user ID 1000
```

#### 2. Mannual stub the `attempt_setup_fake_passwd_entry`, the user is `spark`.
2.1 Apply a tmp change to cmd 

```patch
diff --git a/entrypoint.sh.template b/entrypoint.sh.template
index 08fc925..77d5b04 100644
--- a/entrypoint.sh.template
+++ b/entrypoint.sh.template
@@ -118,6 +118,7 @@ case "$1" in

   *)
     # Non-spark-on-k8s command provided, proceeding in pass-through mode...
+    attempt_setup_fake_passwd_entry
     exec "$@"
     ;;
 esac
```

2.2 Build and run the image, specify a random UID/GID 1000

```bash
$ docker build . -t spark-test
$ docker run -it --rm --user 1000:1000  spark-test bash
# the user is set to spark rather than unknow user
spark@6f41b8e5be9b:/opt/spark/work-dir$
spark@6f41b8e5be9b:/opt/spark/work-dir$ id -u
1000
spark@6f41b8e5be9b:/opt/spark/work-dir$ id -g
1000
spark@6f41b8e5be9b:/opt/spark/work-dir$ whoami
spark

```

```
# NSS env is set right
spark@6f41b8e5be9b:/opt/spark/work-dir$ echo $LD_PRELOAD
/usr/lib/libnss_wrapper.so
spark@6f41b8e5be9b:/opt/spark/work-dir$ echo $NSS_WRAPPER_PASSWD
/tmp/tmp.r5x4SMX35B
spark@6f41b8e5be9b:/opt/spark/work-dir$ cat /tmp/tmp.r5x4SMX35B
spark:x:1000:1000:${SPARK_USER_NAME:-anonymous uid}:/opt/spark:/bin/false
spark@6f41b8e5be9b:/opt/spark/work-dir$ echo $NSS_WRAPPER_GROUP
/tmp/tmp.XcnnYuD68r
spark@6f41b8e5be9b:/opt/spark/work-dir$ cat /tmp/tmp.XcnnYuD68r
spark:x:1000:
```

#### 3. If specify current exsiting user (such as `spark`, `root`), no fake setup
```bash
# docker run -it --rm --user 0  spark-test bash
root@e5bf55d4df22:/opt/spark/work-dir# echo $LD_PRELOAD

```

```bash
# docker run -it --rm  spark-test bash
spark@def8d8ca4e7d:/opt/spark/work-dir$ echo $LD_PRELOAD

```
