### PR TITLE
[SPARK-44176] Change apt to apt-get and remove useless cleanup

### DIFF
--- a/3.4.0/scala2.12-java11-python3-r-ubuntu/Dockerfile
+++ b/3.4.0/scala2.12-java11-python3-r-ubuntu/Dockerfile
@@ -20,9 +20,8 @@ USER root
 
 RUN set -ex; \
     apt-get update; \
-    apt install -y python3 python3-pip; \
-    apt install -y r-base r-base-dev; \
-    rm -rf /var/cache/apt/*; \
+    apt-get install -y python3 python3-pip; \
+    apt-get install -y r-base r-base-dev; \
     rm -rf /var/lib/apt/lists/*
 
 ENV R_HOME /usr/lib/R

--- a/3.4.0/scala2.12-java11-python3-ubuntu/Dockerfile
+++ b/3.4.0/scala2.12-java11-python3-ubuntu/Dockerfile
@@ -20,8 +20,7 @@ USER root
 
 RUN set -ex; \
     apt-get update; \
-    apt install -y python3 python3-pip; \
-    rm -rf /var/cache/apt/*; \
+    apt-get install -y python3 python3-pip; \
     rm -rf /var/lib/apt/lists/*
 
 USER spark

--- a/3.4.0/scala2.12-java11-r-ubuntu/Dockerfile
+++ b/3.4.0/scala2.12-java11-r-ubuntu/Dockerfile
@@ -20,8 +20,7 @@ USER root
 
 RUN set -ex; \
     apt-get update; \
-    apt install -y r-base r-base-dev; \
-    rm -rf /var/cache/apt/*; \
+    apt-get install -y r-base r-base-dev; \
     rm -rf /var/lib/apt/lists/*
 
 ENV R_HOME /usr/lib/R

--- a/3.4.0/scala2.12-java11-ubuntu/Dockerfile
+++ b/3.4.0/scala2.12-java11-ubuntu/Dockerfile
@@ -24,7 +24,7 @@ RUN groupadd --system --gid=${spark_uid} spark && \
 RUN set -ex; \
     apt-get update; \
     ln -s /lib /lib64; \
-    apt install -y gnupg2 wget bash tini libc6 libpam-modules krb5-user libnss3 procps net-tools gosu libnss-wrapper; \
+    apt-get install -y gnupg2 wget bash tini libc6 libpam-modules krb5-user libnss3 procps net-tools gosu libnss-wrapper; \
     mkdir -p /opt/spark; \
     mkdir /opt/spark/python; \
     mkdir -p /opt/spark/examples; \
@@ -33,7 +33,6 @@ RUN set -ex; \
     touch /opt/spark/RELEASE; \
     chown -R spark:spark /opt/spark; \
     echo "auth required pam_wheel.so use_uid" >> /etc/pam.d/su; \
-    rm -rf /var/cache/apt/*; \
     rm -rf /var/lib/apt/lists/*
 
 # Install Apache Spark

--- a/3.4.1/scala2.12-java11-python3-r-ubuntu/Dockerfile
+++ b/3.4.1/scala2.12-java11-python3-r-ubuntu/Dockerfile
@@ -20,9 +20,8 @@ USER root
 
 RUN set -ex; \
     apt-get update; \
-    apt install -y python3 python3-pip; \
-    apt install -y r-base r-base-dev; \
-    rm -rf /var/cache/apt/*; \
+    apt-get install -y python3 python3-pip; \
+    apt-get install -y r-base r-base-dev; \
     rm -rf /var/lib/apt/lists/*
 
 ENV R_HOME /usr/lib/R

--- a/3.4.1/scala2.12-java11-python3-ubuntu/Dockerfile
+++ b/3.4.1/scala2.12-java11-python3-ubuntu/Dockerfile
@@ -20,8 +20,7 @@ USER root
 
 RUN set -ex; \
     apt-get update; \
-    apt install -y python3 python3-pip; \
-    rm -rf /var/cache/apt/*; \
+    apt-get install -y python3 python3-pip; \
     rm -rf /var/lib/apt/lists/*
 
 USER spark

--- a/3.4.1/scala2.12-java11-r-ubuntu/Dockerfile
+++ b/3.4.1/scala2.12-java11-r-ubuntu/Dockerfile
@@ -20,8 +20,7 @@ USER root
 
 RUN set -ex; \
     apt-get update; \
-    apt install -y r-base r-base-dev; \
-    rm -rf /var/cache/apt/*; \
+    apt-get install -y r-base r-base-dev; \
     rm -rf /var/lib/apt/lists/*
 
 ENV R_HOME /usr/lib/R

--- a/3.4.1/scala2.12-java11-ubuntu/Dockerfile
+++ b/3.4.1/scala2.12-java11-ubuntu/Dockerfile
@@ -24,7 +24,7 @@ RUN groupadd --system --gid=${spark_uid} spark && \
 RUN set -ex; \
     apt-get update; \
     ln -s /lib /lib64; \
-    apt install -y gnupg2 wget bash tini libc6 libpam-modules krb5-user libnss3 procps net-tools gosu libnss-wrapper; \
+    apt-get install -y gnupg2 wget bash tini libc6 libpam-modules krb5-user libnss3 procps net-tools gosu libnss-wrapper; \
     mkdir -p /opt/spark; \
     mkdir /opt/spark/python; \
     mkdir -p /opt/spark/examples; \
@@ -33,7 +33,6 @@ RUN set -ex; \
     touch /opt/spark/RELEASE; \
     chown -R spark:spark /opt/spark; \
     echo "auth required pam_wheel.so use_uid" >> /etc/pam.d/su; \
-    rm -rf /var/cache/apt/*; \
     rm -rf /var/lib/apt/lists/*
 
 # Install Apache Spark

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -24,7 +24,7 @@ RUN groupadd --system --gid=${spark_uid} spark && \
 RUN set -ex; \
     apt-get update; \
     ln -s /lib /lib64; \
-    apt install -y gnupg2 wget bash tini libc6 libpam-modules krb5-user libnss3 procps net-tools gosu libnss-wrapper; \
+    apt-get install -y gnupg2 wget bash tini libc6 libpam-modules krb5-user libnss3 procps net-tools gosu libnss-wrapper; \
     mkdir -p /opt/spark; \
     mkdir /opt/spark/python; \
     mkdir -p /opt/spark/examples; \
@@ -33,7 +33,6 @@ RUN set -ex; \
     touch /opt/spark/RELEASE; \
     chown -R spark:spark /opt/spark; \
     echo "auth required pam_wheel.so use_uid" >> /etc/pam.d/su; \
-    rm -rf /var/cache/apt/*; \
     rm -rf /var/lib/apt/lists/*
 
 # Install Apache Spark

--- a/r-python.template
+++ b/r-python.template
@@ -21,12 +21,11 @@ USER root
 RUN set -ex; \
     apt-get update; \
     {%- if HAVE_PY %}
-    apt install -y python3 python3-pip; \
+    apt-get install -y python3 python3-pip; \
     {%- endif %}
     {%- if HAVE_R %}
-    apt install -y r-base r-base-dev; \
+    apt-get install -y r-base r-base-dev; \
     {%- endif %}
-    rm -rf /var/cache/apt/*; \
     rm -rf /var/lib/apt/lists/*
 {%- if HAVE_R %}
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
This patch change `apt` to `apt-get` and also remove useless `rm -rf /var/cache/apt/*; \`.
And also apply the change to 3.4.0 and 3.4.1

### Why are the changes needed?
Address comments from DOI:
- `apt install ...`, This should be apt-get (apt is not intended for unattended use, as the warning during build makes clear).
- `rm -rf /var/cache/apt/*; \` This is harmless, but should be unnecessary (the base image configuration already makes sure this directory stays empty).

See more in:
[1] https://github.com/docker-library/official-images/pull/13089#issuecomment-1601813499


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
CI passed
