### PR TITLE
[SPARK-44175] Remove useless lib64 path link in dockerfile

### DIFF
--- a/3.4.0/scala2.12-java11-ubuntu/Dockerfile
+++ b/3.4.0/scala2.12-java11-ubuntu/Dockerfile
@@ -23,7 +23,6 @@ RUN groupadd --system --gid=${spark_uid} spark && \
 
 RUN set -ex; \
     apt-get update; \
-    ln -s /lib /lib64; \
     apt install -y gnupg2 wget bash tini libc6 libpam-modules krb5-user libnss3 procps net-tools gosu libnss-wrapper; \
     mkdir -p /opt/spark; \
     mkdir /opt/spark/python; \

--- a/3.4.1/scala2.12-java11-ubuntu/Dockerfile
+++ b/3.4.1/scala2.12-java11-ubuntu/Dockerfile
@@ -23,7 +23,6 @@ RUN groupadd --system --gid=${spark_uid} spark && \
 
 RUN set -ex; \
     apt-get update; \
-    ln -s /lib /lib64; \
     apt install -y gnupg2 wget bash tini libc6 libpam-modules krb5-user libnss3 procps net-tools gosu libnss-wrapper; \
     mkdir -p /opt/spark; \
     mkdir /opt/spark/python; \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -23,7 +23,6 @@ RUN groupadd --system --gid=${spark_uid} spark && \
 
 RUN set -ex; \
     apt-get update; \
-    ln -s /lib /lib64; \
     apt install -y gnupg2 wget bash tini libc6 libpam-modules krb5-user libnss3 procps net-tools gosu libnss-wrapper; \
     mkdir -p /opt/spark; \
     mkdir /opt/spark/python; \


### PR DESCRIPTION
### What changes were proposed in this pull request?
Remove useless lib64 path


### Why are the changes needed?
Address comments: https://github.com/docker-library/official-images/pull/13089#issuecomment-1601813499

It was introduced by https://github.com/apache/spark/commit/f13ea15d79fb4752a0a75a05a4a89bd8625ea3d5 to address the issue about snappy on alpine OS, but we already switch the OS to ubuntu, so `/lib64` hack can be cleanup.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
CI passed
