### PR TITLE
[SPARK-44168][FOLLOWUP] Change v3.4 GPG_KEY to full key fingerprint

### DIFF
--- a/3.4.1/scala2.12-java11-ubuntu/Dockerfile
+++ b/3.4.1/scala2.12-java11-ubuntu/Dockerfile
@@ -38,7 +38,7 @@ RUN set -ex; \
 # https://downloads.apache.org/spark/KEYS
 ENV SPARK_TGZ_URL=https://archive.apache.org/dist/spark/spark-3.4.1/spark-3.4.1-bin-hadoop3.tgz \
     SPARK_TGZ_ASC_URL=https://archive.apache.org/dist/spark/spark-3.4.1/spark-3.4.1-bin-hadoop3.tgz.asc \
-    GPG_KEY=34F0FC5C
+    GPG_KEY=F28C9C925C188C35E345614DEDA00CE834F0FC5C
 
 RUN set -ex; \
     export SPARK_TMP="$(mktemp -d)"; \

--- a/tools/template.py
+++ b/tools/template.py
@@ -31,7 +31,7 @@ GPG_KEY_DICT = {
     # issuer "xinrong@apache.org"
     "3.4.0": "CC68B3D16FE33A766705160BA7E57908C7A4E1B1",
     # issuer "dongjoon@apache.org"
-    "3.4.1": "34F0FC5C"
+    "3.4.1": "F28C9C925C188C35E345614DEDA00CE834F0FC5C"
 }
 
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Change GPG key from `34F0FC5C` to `F28C9C925C188C35E345614DEDA00CE834F0FC5C` to avoid pontential collision.

The full finger print can get from below cmd:
```
$ wget https://dist.apache.org/repos/dist/dev/spark/KEYS
$ gpg --import KEYS
$ gpg --fingerprint 34F0FC5C

pub   rsa4096 2015-05-05 [SC]
      F28C 9C92 5C18 8C35 E345  614D EDA0 0CE8 34F0 FC5C
uid           [ unknown] Dongjoon Hyun (CODE SIGNING KEY) <dongjoon@apache.org>
sub   rsa4096 2015-05-05 [E]

```

### Why are the changes needed?

- A short gpg key had been added as v3.4.0 gpg key in https://github.com/apache/spark-docker/pull/46 .
- The short key `34F0FC5C` is from https://dist.apache.org/repos/dist/dev/spark/KEYS
- According DOI review comments, https://github.com/docker-library/official-images/pull/13089#issuecomment-1609990551 , `this should be the full key fingerprint: F28C9C925C188C35E345614DEDA00CE834F0FC5C (generating a collision for such a short key ID is trivial.`
- We'd better to switch the short key to full fingerprint

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
CI passed