### PR TITLE
[SPARK-44494] Pin minikube to v1.30.1 to fix spark-docker K8s CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -243,7 +243,9 @@ jobs:
       - name: Test - Start minikube
         run: |
           # See more in "Installation" https://minikube.sigs.k8s.io/docs/start/
-          curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64
+          # curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64
+          # TODO(SPARK-44495): Resume to use the latest minikube for k8s-integration-tests.
+          curl -LO https://storage.googleapis.com/minikube/releases/v1.30.1/minikube-linux-amd64
           sudo install minikube-linux-amd64 /usr/local/bin/minikube
           # Github Action limit cpu:2, memory: 6947MB, limit to 2U6G for better resource statistic
           minikube start --cpus 2 --memory 6144


### PR DESCRIPTION
### What changes were proposed in this pull request?
Pin minikube to v1.30.1 to fix spark-docker K8s CI.


### Why are the changes needed?
Pin minikube to v1.30.1 to fix spark-docker K8s CI


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
CI passed
