### PR TITLE
[SPARK-46209] Add java 11 only yml for version before 3.5

### DIFF
--- a/.github/workflows/publish-java11.yml
+++ b/.github/workflows/publish-java11.yml
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-name: "Publish"
+name: "Publish (Java 11 only)"
 
 on:
   workflow_dispatch:
@@ -25,10 +25,16 @@ on:
       spark:
         description: 'The Spark version of Spark image.'
         required: true
-        default: '3.5.0'
+        default: '3.4.2'
         type: choice
         options:
-        - 3.5.0
+        - 3.4.2
+        - 3.4.1
+        - 3.4.0
+        - 3.3.3
+        - 3.3.2
+        - 3.3.1
+        - 3.3.0
       publish:
         description: 'Publish the image or not.'
         default: false
@@ -52,7 +58,7 @@ jobs:
     strategy:
       matrix:
         scala: [2.12]
-        java: [11, 17]
+        java: [11]
         image-type: ["scala"]
     permissions:
       packages: write
@@ -74,7 +80,7 @@ jobs:
     strategy:
       matrix:
         scala: [2.12]
-        java: [11, 17]
+        java: [11]
         image-type: ["all", "python", "r"]
     permissions:
       packages: write


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add Java11 only workflow for version before 3.5.0.


### Why are the changes needed?
otherwise, the publish will failed due to no java 17 file founded in version before v 3.5.0.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Test on my repo: https://github.com/Yikun/spark-docker/actions/workflows/publish-java11.yml
