### PR TITLE
[SPARK-47206][FOLLOWUP] Fix wrong path version

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -30,7 +30,7 @@
       ]
     },
     {
-      "path": "3.5.0/scala2.12-java11-python3-ubuntu",
+      "path": "3.5.1/scala2.12-java11-python3-ubuntu",
       "tags": [
         "3.5.1-scala2.12-java11-python3-ubuntu",
         "3.5.1-python3",


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix wrong path version.

### Why are the changes needed?
This will be used by https://github.com/docker-library/official-images .


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?

```
$ tools/manifest.py manifest

Maintainers: Apache Spark Developers <dev@spark.apache.org> (@ApacheSpark)
GitRepo: https://github.com/apache/spark-docker.git

Tags: 3.5.1-scala2.12-java17-python3-ubuntu, 3.5.1-java17-python3, 3.5.1-java17, python3-java17
Architectures: amd64, arm64v8
GitCommit: 8b4329162bbbd1ce5c9d885a1edcd6d61ebcc676
Directory: ./3.5.1/scala2.12-java17-python3-ubuntu

Tags: 3.5.1-scala2.12-java17-r-ubuntu, 3.5.1-java17-r
Architectures: amd64, arm64v8
GitCommit: 8b4329162bbbd1ce5c9d885a1edcd6d61ebcc676
Directory: ./3.5.1/scala2.12-java17-r-ubuntu

Tags: 3.5.1-scala2.12-java17-ubuntu, 3.5.1-java17-scala
Architectures: amd64, arm64v8
GitCommit: 8b4329162bbbd1ce5c9d885a1edcd6d61ebcc676
Directory: ./3.5.1/scala2.12-java17-ubuntu

Tags: 3.5.1-scala2.12-java17-python3-r-ubuntu
Architectures: amd64, arm64v8
GitCommit: 8b4329162bbbd1ce5c9d885a1edcd6d61ebcc676
Directory: ./3.5.1/scala2.12-java17-python3-r-ubuntu

Tags: 3.5.1-scala2.12-java11-python3-ubuntu, 3.5.1-python3, 3.5.1, python3, latest
Architectures: amd64, arm64v8
GitCommit: 8b4329162bbbd1ce5c9d885a1edcd6d61ebcc676
Directory: ./3.5.1/scala2.12-java11-python3-ubuntu

Tags: 3.5.1-scala2.12-java11-r-ubuntu, 3.5.1-r, r
Architectures: amd64, arm64v8
GitCommit: 8b4329162bbbd1ce5c9d885a1edcd6d61ebcc676
Directory: ./3.5.1/scala2.12-java11-r-ubuntu

Tags: 3.5.1-scala2.12-java11-ubuntu, 3.5.1-scala, scala
Architectures: amd64, arm64v8
GitCommit: 8b4329162bbbd1ce5c9d885a1edcd6d61ebcc676
Directory: ./3.5.1/scala2.12-java11-ubuntu

Tags: 3.5.1-scala2.12-java11-python3-r-ubuntu
Architectures: amd64, arm64v8
GitCommit: 8b4329162bbbd1ce5c9d885a1edcd6d61ebcc676
Directory: ./3.5.1/scala2.12-java11-python3-r-ubuntu
```