### PR TITLE
[SPARK-49701] Use JDK for Spark 3.5+ Docker image

### DIFF
--- a/3.5.0/scala2.12-java17-ubuntu/Dockerfile
+++ b/3.5.0/scala2.12-java17-ubuntu/Dockerfile
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM eclipse-temurin:17-jre-jammy
+FROM eclipse-temurin:17-jammy
 
 ARG spark_uid=185
 

--- a/3.5.1/scala2.12-java17-ubuntu/Dockerfile
+++ b/3.5.1/scala2.12-java17-ubuntu/Dockerfile
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM eclipse-temurin:17-jre-jammy
+FROM eclipse-temurin:17-jammy
 
 ARG spark_uid=185
 

--- a/3.5.2/scala2.12-java17-ubuntu/Dockerfile
+++ b/3.5.2/scala2.12-java17-ubuntu/Dockerfile
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM eclipse-temurin:17-jre-jammy
+FROM eclipse-temurin:17-jammy
 
 ARG spark_uid=185
 

--- a/4.0.0-preview1/scala2.13-java17-ubuntu/Dockerfile
+++ b/4.0.0-preview1/scala2.13-java17-ubuntu/Dockerfile
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM eclipse-temurin:17-jre-jammy
+FROM eclipse-temurin:17-jammy
 
 ARG spark_uid=185
 

--- a/add-dockerfiles.sh
+++ b/add-dockerfiles.sh
@@ -72,7 +72,7 @@ for TAG in $TAGS; do
     fi
 
     if echo $TAG | grep -q "java17"; then
-        OPTS+=" --java-version 17 --image eclipse-temurin:17-jre-jammy"
+        OPTS+=" --java-version 17 --image eclipse-temurin:17-jammy"
     elif echo $TAG | grep -q "java11"; then
         OPTS+=" --java-version 11 --image eclipse-temurin:11-jre-focal"
     fi


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use JDK for Spark 3.5+ Docker image. Apache Spark Dockerfile are updated already.
- https://github.com/apache/spark/pull/45762
- https://github.com/apache/spark/pull/45761

### Why are the changes needed?

Since Apache Spark 3.5.0, SPARK-44153 starts to use `jmap` like the following.

- https://github.com/apache/spark/pull/41709

https://github.com/apache/spark/blob/c832e2ac1d04668c77493577662c639785808657/core/src/main/scala/org/apache/spark/util/Utils.scala#L2030

### Does this PR introduce _any_ user-facing change?

Yes, the user can use `Heap Histogram` feature.

### How was this patch tested?

Pass the CIs.