### PR TITLE
[SPARK-44935] Fix `RELEASE` file to have the correct information in Docker images if exists

### DIFF
--- a/3.4.0/scala2.12-java11-ubuntu/Dockerfile
+++ b/3.4.0/scala2.12-java11-ubuntu/Dockerfile
@@ -55,6 +55,7 @@ RUN set -ex; \
     tar -xf spark.tgz --strip-components=1; \
     chown -R spark:spark .; \
     mv jars /opt/spark/; \
+    mv RELEASE /opt/spark/; \
     mv bin /opt/spark/; \
     mv sbin /opt/spark/; \
     mv kubernetes/dockerfiles/spark/decom.sh /opt/; \

--- a/3.4.1/scala2.12-java11-ubuntu/Dockerfile
+++ b/3.4.1/scala2.12-java11-ubuntu/Dockerfile
@@ -55,6 +55,7 @@ RUN set -ex; \
     tar -xf spark.tgz --strip-components=1; \
     chown -R spark:spark .; \
     mv jars /opt/spark/; \
+    mv RELEASE /opt/spark/; \
     mv bin /opt/spark/; \
     mv sbin /opt/spark/; \
     mv kubernetes/dockerfiles/spark/decom.sh /opt/; \

--- a/3.4.2/scala2.12-java11-ubuntu/Dockerfile
+++ b/3.4.2/scala2.12-java11-ubuntu/Dockerfile
@@ -55,6 +55,7 @@ RUN set -ex; \
     tar -xf spark.tgz --strip-components=1; \
     chown -R spark:spark .; \
     mv jars /opt/spark/; \
+    mv RELEASE /opt/spark/; \
     mv bin /opt/spark/; \
     mv sbin /opt/spark/; \
     mv kubernetes/dockerfiles/spark/decom.sh /opt/; \

--- a/3.4.3/scala2.12-java11-ubuntu/Dockerfile
+++ b/3.4.3/scala2.12-java11-ubuntu/Dockerfile
@@ -55,6 +55,7 @@ RUN set -ex; \
     tar -xf spark.tgz --strip-components=1; \
     chown -R spark:spark .; \
     mv jars /opt/spark/; \
+    mv RELEASE /opt/spark/; \
     mv bin /opt/spark/; \
     mv sbin /opt/spark/; \
     mv kubernetes/dockerfiles/spark/decom.sh /opt/; \

--- a/3.5.0/scala2.12-java11-ubuntu/Dockerfile
+++ b/3.5.0/scala2.12-java11-ubuntu/Dockerfile
@@ -55,6 +55,7 @@ RUN set -ex; \
     tar -xf spark.tgz --strip-components=1; \
     chown -R spark:spark .; \
     mv jars /opt/spark/; \
+    mv RELEASE /opt/spark/; \
     mv bin /opt/spark/; \
     mv sbin /opt/spark/; \
     mv kubernetes/dockerfiles/spark/decom.sh /opt/; \

--- a/3.5.0/scala2.12-java17-ubuntu/Dockerfile
+++ b/3.5.0/scala2.12-java17-ubuntu/Dockerfile
@@ -55,6 +55,7 @@ RUN set -ex; \
     tar -xf spark.tgz --strip-components=1; \
     chown -R spark:spark .; \
     mv jars /opt/spark/; \
+    mv RELEASE /opt/spark/; \
     mv bin /opt/spark/; \
     mv sbin /opt/spark/; \
     mv kubernetes/dockerfiles/spark/decom.sh /opt/; \

--- a/3.5.1/scala2.12-java11-ubuntu/Dockerfile
+++ b/3.5.1/scala2.12-java11-ubuntu/Dockerfile
@@ -55,6 +55,7 @@ RUN set -ex; \
     tar -xf spark.tgz --strip-components=1; \
     chown -R spark:spark .; \
     mv jars /opt/spark/; \
+    mv RELEASE /opt/spark/; \
     mv bin /opt/spark/; \
     mv sbin /opt/spark/; \
     mv kubernetes/dockerfiles/spark/decom.sh /opt/; \

--- a/3.5.1/scala2.12-java17-ubuntu/Dockerfile
+++ b/3.5.1/scala2.12-java17-ubuntu/Dockerfile
@@ -55,6 +55,7 @@ RUN set -ex; \
     tar -xf spark.tgz --strip-components=1; \
     chown -R spark:spark .; \
     mv jars /opt/spark/; \
+    mv RELEASE /opt/spark/; \
     mv bin /opt/spark/; \
     mv sbin /opt/spark/; \
     mv kubernetes/dockerfiles/spark/decom.sh /opt/; \

--- a/3.5.2/scala2.12-java11-ubuntu/Dockerfile
+++ b/3.5.2/scala2.12-java11-ubuntu/Dockerfile
@@ -55,6 +55,7 @@ RUN set -ex; \
     tar -xf spark.tgz --strip-components=1; \
     chown -R spark:spark .; \
     mv jars /opt/spark/; \
+    mv RELEASE /opt/spark/; \
     mv bin /opt/spark/; \
     mv sbin /opt/spark/; \
     mv kubernetes/dockerfiles/spark/decom.sh /opt/; \

--- a/3.5.2/scala2.12-java17-ubuntu/Dockerfile
+++ b/3.5.2/scala2.12-java17-ubuntu/Dockerfile
@@ -55,6 +55,7 @@ RUN set -ex; \
     tar -xf spark.tgz --strip-components=1; \
     chown -R spark:spark .; \
     mv jars /opt/spark/; \
+    mv RELEASE /opt/spark/; \
     mv bin /opt/spark/; \
     mv sbin /opt/spark/; \
     mv kubernetes/dockerfiles/spark/decom.sh /opt/; \

--- a/4.0.0-preview1/scala2.13-java17-ubuntu/Dockerfile
+++ b/4.0.0-preview1/scala2.13-java17-ubuntu/Dockerfile
@@ -55,6 +55,7 @@ RUN set -ex; \
     tar -xf spark.tgz --strip-components=1; \
     chown -R spark:spark .; \
     mv jars /opt/spark/; \
+    mv RELEASE /opt/spark/; \
     mv bin /opt/spark/; \
     mv sbin /opt/spark/; \
     mv kubernetes/dockerfiles/spark/decom.sh /opt/; \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -55,6 +55,7 @@ RUN set -ex; \
     tar -xf spark.tgz --strip-components=1; \
     chown -R spark:spark .; \
     mv jars /opt/spark/; \
+    mv RELEASE /opt/spark/; \
     mv bin /opt/spark/; \
     mv sbin /opt/spark/; \
     mv kubernetes/dockerfiles/spark/decom.sh /opt/; \


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix `RELEASE` file to have the correct information in Docker images if exists.

Apache Spark repository already fixed this.
- https://github.com/apache/spark/pull/42636

### Why are the changes needed?

To provide a correct information for Spark 3.4+

### Does this PR introduce _any_ user-facing change?

No behavior change. Only `RELEASE` file.

### How was this patch tested?

Pass the CIs.