### PR TITLE
[SPARK-49740] Update `publish-java17.yaml` and `publish-java21.yaml` to use `preview2` by default

### DIFF
--- a/.github/workflows/publish-java17.yaml
+++ b/.github/workflows/publish-java17.yaml
@@ -25,10 +25,11 @@ on:
       spark:
         description: 'The Spark version of Spark image.'
         required: true
-        default: '4.0.0-preview1'
+        default: '4.0.0-preview2'
         type: choice
         options:
         - 4.0.0-preview1
+        - 4.0.0-preview2
       publish:
         description: 'Publish the image or not.'
         default: false

--- a/.github/workflows/publish-java21.yaml
+++ b/.github/workflows/publish-java21.yaml
@@ -25,10 +25,11 @@ on:
       spark:
         description: 'The Spark version of Spark image.'
         required: true
-        default: '4.0.0-preview1'
+        default: '4.0.0-preview2'
         type: choice
         options:
         - 4.0.0-preview1
+        - 4.0.0-preview2
       publish:
         description: 'Publish the image or not.'
         default: false


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update `publish-java17.yaml` and `publish-java21.yaml` to use `preview2` by default.

### Why are the changes needed?

To publish the latest images.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review.