### PR TITLE
Install r for ubuntu-latest

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -257,6 +257,11 @@ jobs:
           path: ~/.cache/coursier
           key: build-${{ inputs.spark }}-scala${{ inputs.scala }}-java${{ inputs.java }}-coursier
 
+      - name: Install R
+        run: |
+            sudo apt update
+            sudo apt-get install r-base
+
       - name: Test - Start minikube
         run: |
           # See more in "Installation" https://minikube.sigs.k8s.io/docs/start/


### PR DESCRIPTION
### What changes were proposed in this pull request?
ubuntu-latest no longer includes the runtime environment for R, which has led to the following error in testing:

```
+++ dirname /home/runner/work/spark-docker/spark-docker/spark/core/../R/install-dev.sh
++ cd /home/runner/work/spark-docker/spark-docker/spark/core/../R
++ pwd
+ FWDIR=/home/runner/work/spark-docker/spark-docker/spark/R
+ LIB_DIR=/home/runner/work/spark-docker/spark-docker/spark/R/lib
+ mkdir -p /home/runner/work/spark-docker/spark-docker/spark/R/lib
+ pushd /home/runner/work/spark-docker/spark-docker/spark/R
+ . /home/runner/work/spark-docker/spark-docker/spark/R/find-r.sh
++ '[' -z '' ']'
++ '[' '!' -z '' ']'
+++ command -v R
++ '[' '!' ']'
++ echo 'Cannot find '\''R_HOME'\''. Please specify '\''R_HOME'\'' or make sure R is properly installed.'
++ exit 1
[error] java.lang.RuntimeException: Nonzero exit value: 1
[error] 	at scala.sys.package$.error(package.scala:30)
[error] 	at scala.sys.process.ProcessBuilderImpl$AbstractBuilder.slurp(ProcessBuilderImpl.scala:138)
[error] 	at scala.sys.process.ProcessBuilderImpl$AbstractBuilder.$bang$bang(ProcessBuilderImpl.scala:108)
[error] 	at SparkR$.$anonfun$settings$124(SparkBuild.scala:1355)
[error] 	at SparkR$.$anonfun$settings$124$adapted(SparkBuild.scala:1352)
[error] 	at scala.Function1.$anonfun$compose$1(Function1.scala:49)
[error] 	at sbt.internal.util.$tilde$greater.$anonfun$$u2219$1(TypeFunctions.scala:63)
[error] 	at sbt.std.Transform$$anon$4.work(Transform.scala:69)
[error] 	at sbt.Execute.$anonfun$submit$2(Execute.scala:283)
[error] 	at sbt.internal.util.ErrorHandling$.wideConvert(ErrorHandling.scala:24)
[error] 	at sbt.Execute.work(Execute.scala:292)
[error] 	at sbt.Execute.$anonfun$submit$1(Execute.scala:283)
[error] 	at sbt.ConcurrentRestrictions$$anon$4.$anonfun$submitValid$1(ConcurrentRestrictions.scala:265)
[error] 	at sbt.CompletionService$$anon$2.call(CompletionService.scala:65)
[error] 	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
[error] 	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
[error] 	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
[error] 	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
[error] 	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
[error] 	at java.base/java.lang.Thread.run(Thread.java:829)
[error] (core / buildRPackage) Nonzero exit value: 1
[error] Total time: 12 s, completed Dec 20, 2024, 5:24:08 PM

Error: Process completed with exit code 1.
``` 

This pr manually installs `r-base` to fix the GitHub Actions testing environment. This fix was refer to SPARK-49920

### Why are the changes needed?
Install r for ubuntu-latest


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
CI