### PR TITLE
add home dir for spark user

### DIFF
--- a/3.5.4/scala2.12-java11-ubuntu/Dockerfile
+++ b/3.5.4/scala2.12-java11-ubuntu/Dockerfile
@@ -19,7 +19,7 @@ FROM eclipse-temurin:11-jre-focal
 ARG spark_uid=185
 
 RUN groupadd --system --gid=${spark_uid} spark && \
-    useradd --system --uid=${spark_uid} --gid=spark spark
+    useradd -m --system --uid=${spark_uid} --gid=spark spark
 
 RUN set -ex; \
     apt-get update; \

--- a/3.5.4/scala2.12-java17-ubuntu/Dockerfile
+++ b/3.5.4/scala2.12-java17-ubuntu/Dockerfile
@@ -19,7 +19,7 @@ FROM eclipse-temurin:17-jammy
 ARG spark_uid=185
 
 RUN groupadd --system --gid=${spark_uid} spark && \
-    useradd --system --uid=${spark_uid} --gid=spark spark
+    useradd -m --system --uid=${spark_uid} --gid=spark spark
 
 RUN set -ex; \
     apt-get update; \

--- a/4.0.0-preview1/scala2.13-java17-ubuntu/Dockerfile
+++ b/4.0.0-preview1/scala2.13-java17-ubuntu/Dockerfile
@@ -19,7 +19,7 @@ FROM eclipse-temurin:17-jammy
 ARG spark_uid=185
 
 RUN groupadd --system --gid=${spark_uid} spark && \
-    useradd --system --uid=${spark_uid} --gid=spark spark
+    useradd -m --system --uid=${spark_uid} --gid=spark spark
 
 RUN set -ex; \
     apt-get update; \

--- a/4.0.0-preview1/scala2.13-java21-ubuntu/Dockerfile
+++ b/4.0.0-preview1/scala2.13-java21-ubuntu/Dockerfile
@@ -19,7 +19,7 @@ FROM eclipse-temurin:21-jammy
 ARG spark_uid=185
 
 RUN groupadd --system --gid=${spark_uid} spark && \
-    useradd --system --uid=${spark_uid} --gid=spark spark
+    useradd -m --system --uid=${spark_uid} --gid=spark spark
 
 RUN set -ex; \
     apt-get update; \

--- a/4.0.0-preview2/scala2.13-java17-ubuntu/Dockerfile
+++ b/4.0.0-preview2/scala2.13-java17-ubuntu/Dockerfile
@@ -19,7 +19,7 @@ FROM eclipse-temurin:17-jammy
 ARG spark_uid=185
 
 RUN groupadd --system --gid=${spark_uid} spark && \
-    useradd --system --uid=${spark_uid} --gid=spark spark
+    useradd -m --system --uid=${spark_uid} --gid=spark spark
 
 RUN set -ex; \
     apt-get update; \

--- a/4.0.0-preview2/scala2.13-java21-ubuntu/Dockerfile
+++ b/4.0.0-preview2/scala2.13-java21-ubuntu/Dockerfile
@@ -19,7 +19,7 @@ FROM eclipse-temurin:21-jammy
 ARG spark_uid=185
 
 RUN groupadd --system --gid=${spark_uid} spark && \
-    useradd --system --uid=${spark_uid} --gid=spark spark
+    useradd -m --system --uid=${spark_uid} --gid=spark spark
 
 RUN set -ex; \
     apt-get update; \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -19,7 +19,7 @@ FROM {{ BASE_IMAGE }}
 ARG spark_uid=185
 
 RUN groupadd --system --gid=${spark_uid} spark && \
-    useradd --system --uid=${spark_uid} --gid=spark spark
+    useradd -m --system --uid=${spark_uid} --gid=spark spark
 
 RUN set -ex; \
     apt-get update; \


### PR DESCRIPTION
It seems running basic commands inside the container like installing additional python packages with pip fails due to a lack of a home directory for the spark user. This PR solves that.

Not sure if that matches with the intended use-cases of the container but people are struggling with it.

related issues online:
https://stackoverflow.com/questions/75560836/apach-spark-py-docker-image-error-could-not-install-packages-due-to-an-oserror
https://stackoverflow.com/questions/2662598/grails-date-property-editor
https://github.com/benniehaelen/delta-lake-up-and-running/issues/5