### PR TITLE
[SPARK-51336] Upgrade `upload-artifact` to v4 in `spark-docker` repository

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -323,7 +323,7 @@ jobs:
 
       - name: Test - Upload Spark on K8S integration tests log files
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: spark-on-kubernetes-it-log
           path: "**/target/integration-tests.log"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `upload-artifact` to v4 in `spark-docker` repository in order to recover the CIs.

### Why are the changes needed?

Currently, this repository CI is broken.
- https://github.com/apache/spark-docker/pull/80
```
Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs on this PR.