### PR TITLE
[SPARK-51344] Fix `ENV` key value format in `*.template`

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -72,7 +72,7 @@ RUN set -ex; \
 
 COPY entrypoint.sh /opt/
 
-ENV SPARK_HOME /opt/spark
+ENV SPARK_HOME=/opt/spark
 
 WORKDIR /opt/spark/work-dir
 

--- a/r-python.template
+++ b/r-python.template
@@ -29,7 +29,7 @@ RUN set -ex; \
     rm -rf /var/lib/apt/lists/*
 {%- if HAVE_R %}
 
-ENV R_HOME /usr/lib/R
+ENV R_HOME=/usr/lib/R
 {%- endif %}
 
 USER spark


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix `ENV` key value format in `*.template` in order to generate the future Dockerfiles correctly.

### Why are the changes needed?

To follow the Docker guideline to fix the following legacy format.
- https://docs.docker.com/reference/build-checks/legacy-key-value-format/

```
    - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format
```

We already fixed Apache Spark Dockerfiles in the main repository.
- https://github.com/apache/spark/pull/47357

### Does this PR introduce _any_ user-facing change?

No. This removes a warning for now.

### How was this patch tested?

Manual review.