### PR TITLE
[SPARK-53475] Use `setup-minikube` in `spark-docker` repository

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -266,14 +266,10 @@ jobs:
             sudo apt-get install r-base
 
       - name: Test - Start minikube
-        run: |
-          # See more in "Installation" https://minikube.sigs.k8s.io/docs/start/
-          # curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64
-          curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64
-          sudo install minikube-linux-amd64 /usr/local/bin/minikube
-          rm minikube-linux-amd64
-          # Github Action limit cpu:2, memory: 6947MB, limit to 2U6G for better resource statistic
-          minikube start --cpus 2 --memory 6144
+        uses: medyagh/setup-minikube@v0.0.20
+        with:
+          cpus: 2
+          memory: 6144m
 
       - name: Test - Print K8S pods and nodes info
         run: |


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use `setup-minikube` in `spark-docker` repository.

### Why are the changes needed?

To simplify the GitHub Action:
- `setup-minikube` is ASF-approved GitHub Action.
- All Apache Spark repositories (except `spark-docker`) have been using `setup-minikube` as of now.

Currently, `v0.0.20` is the latest one.
- https://github.com/medyagh/setup-minikube/releases/tag/v0.0.20 (2025-07-08)

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.