### PR TITLE
[SPARK-53730] Switch Spark 3.5 Java 11 docker registry images to 11-jammy

### DIFF
--- a/3.5.7/scala2.12-java11-ubuntu/Dockerfile
+++ b/3.5.7/scala2.12-java11-ubuntu/Dockerfile
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM eclipse-temurin:11-jre-focal
+FROM eclipse-temurin:11-jammy
 
 ARG spark_uid=185
 

--- a/add-dockerfiles.sh
+++ b/add-dockerfiles.sh
@@ -80,7 +80,7 @@ for TAG in $TAGS; do
     elif echo $TAG | grep -q "java17"; then
         OPTS+=" --java-version 17 --image eclipse-temurin:17-jammy"
     elif echo $TAG | grep -q "java11"; then
-        OPTS+=" --java-version 11 --image eclipse-temurin:11-jre-focal"
+        OPTS+=" --java-version 11 --image eclipse-temurin:11-jammy"
     fi
     
     OPTS+=" --spark-version $VERSION"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to switch future Apache Spark 3.5 Java 11 docket images to `11-jammy`.
We have applied a similar change to Apache Spark repo Java 17 dockerfile in [SPARK-49005](https://issues.apache.org/jira/browse/SPARK-49005) / https://github.com/apache/spark/pull/47488.

### Why are the changes needed?

The current `11-jre-focal` is no longer supported by Docker Library: https://github.com/docker-library/official-images/pull/19948#issuecomment-3335268352

### Does this PR introduce _any_ user-facing change?

No, we will not republish the 3.5.7 Apache Docker Hub image.

### How was this patch tested?

Manual review.