### PR TITLE
[SPARK-56775] Update `docker/*` GitHub Actions to ASF-approved commit hashes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -158,14 +158,14 @@ jobs:
 
       - name: Build - Set up QEMU
         if: ${{ inputs.build }}
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a
         with:
           ## Temporary due to bug in qemu:  https://github.com/docker/setup-qemu-action/issues/198
           image: tonistiigi/binfmt:qemu-v7.0.0-28
 
       - name: Build - Set up Docker Buildx
         if: ${{ inputs.build }}
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
         with:
           # This required by local registry
           driver-opts: network=host
@@ -173,7 +173,7 @@ jobs:
       - name: Build - Build the base image
         # Don't need to build the base image when publish
         if: ${{ inputs.build && !inputs.publish }}
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f
         with:
           context: ${{ env.BASE_IMAGE_PATH }}
           tags: ${{ env.BASE_IMAGE_URL }}
@@ -196,7 +196,7 @@ jobs:
 
       - name: Build - Build and push test image
         if: ${{ inputs.build }}
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f
         with:
           context: ${{ env.IMAGE_PATH }}
           tags: ${{ env.IMAGE_URL }}
@@ -329,7 +329,7 @@ jobs:
 
       - name: Publish - Login to GitHub Container Registry
         if: ${{ inputs.publish }}
-        uses: docker/login-action@v2
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -337,14 +337,14 @@ jobs:
 
       - name: Publish - Login to Dockerhub Registry
         if: ${{ inputs.publish }}
-        uses: docker/login-action@v2
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Publish - Push Image
         if: ${{ inputs.publish }}
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f
         with:
           context: ${{ env.IMAGE_PATH }}
           push: true


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR updates all `docker/*` GitHub Actions in `.github/workflows/main.yml` from major version tags to ASF-approved commit hashes registered in [`apache/infrastructure-actions/approved_patterns.yml`](https://raw.githubusercontent.com/apache/infrastructure-actions/main/approved_patterns.yml).

| Action | Before | After (latest approved) |
|---|---|---|
| `docker/setup-qemu-action` | `@v3` | `@ce360397dd3f832beb865e1373c09c0e9f86d70a` (v4.0.0) |
| `docker/setup-buildx-action` | `@v2` | `@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd` (v4.0.0) |
| `docker/build-push-action` (×3) | `@v3` | `@bcafcacb16a39f128d818304e6c9c0c18556b85f` (v7.1.0) |
| `docker/login-action` (×2) | `@v2` | `@4907a6ddec9925e35a0a9e82d7399ccc52663121` (v4.1.0) |

### Why are the changes needed?

ASF Infrastructure policy requires GitHub Actions to be pinned to commit hashes listed in `approved_patterns.yml`. The current `docker/*` references use legacy major version tags (`@v2`/`@v3`) that are out of compliance and several major versions behind upstream.

Currently, CI is broken.
> The actions docker/setup-qemu-action@v3, docker/setup-buildx-action@v2, docker/build-push-action@v3, and docker/login-action@v2 are not allowed in apache/spark-docker because all actions must be from a repository owned by your enterprise, created by GitHub, or match one of the patterns: 

For other Apache Spark repositories, we updated already but `spark-docker` seems to be outdated.

- https://github.com/apache/spark/pull/55687
- https://github.com/apache/spark-kubernetes-operator/pull/651

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7 (1M context)