### PR TITLE
[SPARK-56783] Disable `volcano` profile in K8S IT

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -284,6 +284,7 @@ jobs:
 
           eval $(minikube docker-env)
           OPTS="-Pkubernetes -Pkubernetes-integration-tests "
+          OPTS+='-P!volcano '
           OPTS+="-Dspark.kubernetes.test.driverRequestCores=0.5 -Dspark.kubernetes.test.executorRequestCores=0.2 "
           OPTS+="-Dspark.kubernetes.test.deployMode=minikube "
           OPTS+="-Dspark.kubernetes.test.imageRepo=${TEST_REPO} -Dspark.kubernetes.test.imageTag=${UNIQUE_IMAGE_TAG} "


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to disable the `volcano` profile during Kubernetes integration tests by appending `-P!volcano` to the sbt invocation in `.github/workflows/main.yml`.

### Why are the changes needed?

Starting from Apache Spark `v4.2.0-preview5`, the `volcano` profile is enabled by default.

- https://github.com/apache/spark/pull/53693

Because this repository's K8S IT workflow runs on a `minikube` cluster without a Volcano scheduler installed, the auto-activated profile pulls in the `volcano-client` dependency and Volcano-specific test sources, which can fail the test step. Adding `-P!volcano` (Maven's standard profile-deactivation syntax) explicitly disables the profile.

For previous versions (3.5.x / 4.0.x / 4.1.x), `volcano` is not active by default, so `-P!volcano` is a no-op and does not affect their builds.

### Does this PR introduce _any_ user-facing change?

No. This is a CI-only change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (claude-opus-4-7)