### PR TITLE
[SPARK-56784] Upgrade `medyagh/setup-minikube` to v0.0.21

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -266,7 +266,7 @@ jobs:
             sudo apt-get install r-base
 
       - name: Test - Start minikube
-        uses: medyagh/setup-minikube@v0.0.20
+        uses: medyagh/setup-minikube@e9e035a86bbc3caea26a450bd4dbf9d0c453682e # v0.0.21
         with:
           cpus: 2
           memory: 6144m


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `medyagh/setup-minikube` from `v0.0.20` to `v0.0.21` in `.github/workflows/main.yml`, pinned to its commit hash with a version comment.

```diff
       - name: Test - Start minikube
-        uses: medyagh/setup-minikube@v0.0.20
+        uses: medyagh/setup-minikube@e9e035a86bbc3caea26a450bd4dbf9d0c453682e # v0.0.21
```

### Why are the changes needed?

`medyagh/setup-minikube@v0.0.21` was [released on 2025-12-14](https://github.com/medyagh/setup-minikube/releases/tag/v0.0.21). `apache/spark` and `apache/spark-kubernetes-operator` already use `v0.0.21`; this PR keeps `apache/spark-docker` aligned like the other Apache Spark repositories.

- https://github.com/apache/spark/pull/54087
- https://github.com/apache/spark-kubernetes-operator/pull/441

The pinned-hash + version-comment form matches the pattern used by `apache/spark` and the recent SPARK-56775 cleanup in this repository. ASF infra [`approved_patterns.yml`](https://raw.githubusercontent.com/apache/infrastructure-actions/main/approved_patterns.yml) registers `medyagh/setup-minikube@*`, so any version is allowed.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7 (1M context)