### PR TITLE
[SPARK-56783][FOLLOWUP] Use `sed` instead because sbt-pom-reader is unable to disable

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -282,9 +282,10 @@ jobs:
           kubectl create clusterrolebinding serviceaccounts-cluster-admin --clusterrole=cluster-admin --group=system:serviceaccounts || true
           minikube image load ${{ env.IMAGE_URL }}
 
+          sed -i '/<id>volcano<\/id>/,/<\/profile>/ s|<activeByDefault>true</activeByDefault>|<activeByDefault>false</activeByDefault>|' resource-managers/kubernetes/integration-tests/pom.xml
+
           eval $(minikube docker-env)
           OPTS="-Pkubernetes -Pkubernetes-integration-tests "
-          OPTS+='-P!volcano '
           OPTS+="-Dspark.kubernetes.test.driverRequestCores=0.5 -Dspark.kubernetes.test.executorRequestCores=0.2 "
           OPTS+="-Dspark.kubernetes.test.deployMode=minikube "
           OPTS+="-Dspark.kubernetes.test.imageRepo=${TEST_REPO} -Dspark.kubernetes.test.imageTag=${UNIQUE_IMAGE_TAG} "


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup of SPARK-56783 and aims to disable Apache Spark's `volcano` profile during K8S IT by patching the checked-out `pom.xml` with `sed` instead of relying on the `-P!volcano` sbt option.
- https://github.com/apache/spark-docker/pull/111

### Why are the changes needed?

The previously added `-P!volcano` is a Maven CLI deactivation syntax that sbt's `sbt-pom-reader` does not honor. In Apache Spark's `project/SparkBuild.scala`, the profile parser strips only the `-P` prefix and then feeds `!volcano` back as a profile name to activate, which is silently ignored. The `volcano` profile in `resource-managers/kubernetes/integration-tests/pom.xml` is `activeByDefault=true` since `v4.2.0-preview5`, so it remained active and caused `VolcanoSuite` to run and fail on the `minikube` cluster:

```
[info] VolcanoSuite:
[info] - SPARK-42190: Run SparkPi with local[*] *** FAILED *** (3 minutes, 3 seconds)
```

This change instead patches the checked-out `pom.xml` so the `volcano` profile is no longer `activeByDefault`, which works regardless of whether sbt or Maven is invoked. It is a no-op for Spark `<= 4.1.x` where `volcano` is not `activeByDefault`.

### Does this PR introduce _any_ user-facing change?

No. This is a CI-only change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7 (1M context)