### PR TITLE
Add AGENTS.md + SECURITY.md for scan-agent discoverability

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,14 @@
+# Agent guidance
+
+This file is read by automated agents (security scanners, code
+analyzers, AI assistants) operating on this repository. It
+points them at the human-authored references they should
+consult before producing output.
+
+## Security
+
+Security model: [SECURITY.md](./SECURITY.md)
+
+Agents that scan this repository should consult `SECURITY.md`
+for the project's threat model, in-scope / out-of-scope
+declarations, and known non-findings before reporting issues.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,7 +5,7 @@
 To report a security vulnerability in apache/spark-docker,
 follow the ASF security process at
 <https://www.apache.org/security/>. Reports can be sent privately
-to security@apache.org or to security@spark.apache.org.
+to security@apache.org or to private@spark.apache.org.
 
 ## Threat model
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,26 @@
+# Security policy
+
+## Reporting a vulnerability
+
+To report a security vulnerability in apache/spark-docker,
+follow the ASF security process at
+<https://www.apache.org/security/>. Reports can be sent privately
+to security@apache.org or to security@spark.apache.org.
+
+## Threat model
+
+This repository builds the official container images for
+Apache Spark. Apache Spark's security guidance for operators
+— including the trust boundaries the published images
+inherit — is documented at:
+
+<https://spark.apache.org/docs/latest/security.html>
+
+That document covers authentication, encryption, access
+control, Kerberos integration, trust boundaries, environmental
+assumptions, security properties provided and not provided,
+and downstream operator responsibilities.
+
+Automated security scanning agents should consult that
+document for the project's in-scope / out-of-scope
+declarations before reporting issues.


### PR DESCRIPTION
**This is a proposal for the PMC to review — please correct, reject, or discuss as needed.** Nothing here is a requirement; the maintainer is the decision-maker.

This adds `AGENTS.md` and `SECURITY.md` to the repo root so an automated scan agent can mechanically discover the project's security model via the conventional `AGENTS.md → SECURITY.md → model URL` chain. The chain terminates at the existing <https://spark.apache.org/docs/latest/security.html> page — nothing about the model content itself changes.

Context: the ASF Security team is preparing the project for an automated agentic security scan we're piloting. Such scans refuse to run if the model isn't discoverable by that path (refusing upfront beats wasting PMC reviewer cycles on a noise-heavy run against an unknown model). Discoverability is the one hard gate; everything else is suggestion. The Security team has reached out separately on the PMC's private list with the program details; this PR is the public-facing repo piece.

The Security team uses [`threat-model-producer`](https://gist.github.com/potiuk/da14a826283038ddfe38cc9fe6310573) as the rubric for what a complete model looks like — but this PR is just the *links*; the existing Spark `security.html` content is accepted as the model (the published container images inherit the same trust boundaries the operator documentation describes).

Questions / pushback welcome. Happy to adjust the wording or move things if the project has a house style.
