### PR TITLE
[SPARK-57289] Remove Spark 3.3.x and 3.4.x GPG keys

### DIFF
--- a/tools/template.py
+++ b/tools/template.py
@@ -22,24 +22,6 @@ from argparse import ArgumentParser
 from jinja2 import Environment, FileSystemLoader
 
 GPG_KEY_DICT = {
-    # issuer "maxgekk@apache.org"
-    "3.3.0": "80FB8EBE8EBA68504989703491B5DC815DBF10D3",
-    # issuer "yumwang@apache.org"
-    "3.3.1": "86727D43E73A415F67A0B1A14E68B3E6CD473653",
-    # issuer "viirya@apache.org"
-    "3.3.2": "C56349D886F2B01F8CAE794C653C2301FEA493EE",
-    # issuer "yumwang@apache.org"
-    "3.3.3": "F6468A4FF8377B4F1C07BC2AA077F928A0BF68D8",
-    # issuer "xinrong@apache.org"
-    "3.4.0": "CC68B3D16FE33A766705160BA7E57908C7A4E1B1",
-    # issuer "dongjoon@apache.org"
-    "3.4.1": "F28C9C925C188C35E345614DEDA00CE834F0FC5C",
-    # issuer "dongjoon@apache.org"
-    "3.4.2": "F28C9C925C188C35E345614DEDA00CE834F0FC5C",
-    # issuer "dongjoon@apache.org"
-    "3.4.3": "F28C9C925C188C35E345614DEDA00CE834F0FC5C",
-    # issuer "dongjoon@apache.org"
-    "3.4.4": "F28C9C925C188C35E345614DEDA00CE834F0FC5C",
     # issuer "liyuanjian@apache.org"
     "3.5.0": "FC3AE3A7EAA1BAC98770840E7E1ABCC53AAA2216",
     # issuer "kabhwan@apache.org"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove Spark 3.3.x and Spark 3.4.x GPG keys from `template.py`.

### Why are the changes needed?

To clean up outdated code by removing EOL data.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.8