### PR TITLE
[SPARK-57292] Add `publish-java25.yaml` to publish Java 25-based docker images

### DIFF
--- a/.github/workflows/publish-java25.yaml
+++ b/.github/workflows/publish-java25.yaml
@@ -1,0 +1,88 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: "Publish (Java 25 only)"
+
+on:
+  workflow_dispatch:
+    inputs:
+      spark:
+        description: 'The Spark version of Spark image.'
+        required: true
+        default: '4.2.0'
+        type: choice
+        options:
+        - 4.2.0
+      publish:
+        description: 'Publish the image or not.'
+        default: false
+        type: boolean
+        required: true
+      repository:
+        description: The registry to be published (Available only when publish is true).
+        required: false
+        default: ghcr.io/apache/spark-docker
+        type: choice
+        options:
+        # GHCR: This required the write permission of apache/spark-docker (Spark Committer)
+        - ghcr.io/apache/spark-docker
+        # Dockerhub: This required the DOCKERHUB_TOKEN and DOCKERHUB_USER (Spark Committer)
+        - apache
+
+jobs:
+  # We first build and publish the base image
+  run-base-build:
+    strategy:
+      matrix:
+        scala: [2.13]
+        java: [25]
+        image-type: ["scala"]
+    permissions:
+      packages: write
+    name: Run Base
+    secrets: inherit
+    uses: ./.github/workflows/main.yml
+    with:
+      spark: ${{ inputs.spark }}
+      scala: ${{ matrix.scala }}
+      java: ${{ matrix.java }}
+      publish: ${{ inputs.publish }}
+      repository: ${{ inputs.repository }}
+      image-type: ${{ matrix.image-type }}
+
+  # Then publish the all / python / r images
+  run-build:
+    needs: run-base-build
+    strategy:
+      matrix:
+        scala: [2.13]
+        java: [25]
+        image-type: ["all", "python", "r"]
+    permissions:
+      packages: write
+    name: Run
+    secrets: inherit
+    uses: ./.github/workflows/main.yml
+    with:
+      spark: ${{ inputs.spark }}
+      scala: ${{ matrix.scala }}
+      java: ${{ matrix.java }}
+      publish: ${{ inputs.publish }}
+      repository: ${{ inputs.repository }}
+      image-type: ${{ matrix.image-type }}

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ You can see [3.4.0 PR](https://github.com/apache/spark-docker/pull/33) as refere
 
 ### Step 2. Publish apache/spark Images.
 
-Click [Publish (Java 21 only)](https://github.com/apache/spark-docker/actions/workflows/publish-java21.yaml), [Publish (Java 17 only)](https://github.com/apache/spark-docker/actions/workflows/publish-java17.yaml) (such as 4.x) or [Publish](https://github.com/apache/spark-docker/actions/workflows/publish.yml) (such as 3.x) to publish images.
+Click [Publish (Java 25 only)](https://github.com/apache/spark-docker/actions/workflows/publish-java25.yaml), [Publish (Java 21 only)](https://github.com/apache/spark-docker/actions/workflows/publish-java21.yaml), [Publish (Java 17 only)](https://github.com/apache/spark-docker/actions/workflows/publish-java17.yaml) or [Publish](https://github.com/apache/spark-docker/actions/workflows/publish.yml) (such as 3.x) to publish images.
 
 After this, the [apache/spark](https://hub.docker.com/r/apache/spark) docker images will be published.
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `publish-java25.yaml` to publish Java 25-based docker images.

### Why are the changes needed?

Since Apache Spark 4.2.0 starts to support Java 25 via SPARK-51167, we need to prepare to publish Java25-based images.

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Manual review only.

Unfortunately, we cannot publish Java25-based images until 4.2.0-preview5.
So, Apache Spark 4.2.0 is the first release to have this, we need to test with 4.2.0.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 4.8)