### PR TITLE
[SPARK-57300] Recommend `apache/*` images

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ After this, the [spark](https://hub.docker.com/_/spark) docker images will be pu
 | Link          | https://hub.docker.com/r/apache/spark                  | https://hub.docker.com/_/spark                         |
 | source        | [apache/spark-docker](https://github.com/apache/spark-docker)                                           | [apache/spark-docker](https://github.com/apache/spark-docker) and [docker-library/official-images](https://github.com/docker-library/official-images/blob/master/library/spark)     |
 
-We recommend using [Spark Docker Official Image](https://hub.docker.com/_/spark), the [Apache Spark Image](https://hub.docker.com/r/apache/spark) are provided in case of delays in the review process by Docker community.
+We advise using official [Apache Spark images](https://hub.docker.com/r/apache/spark) to maintain architectural uniformity across related projects, including the [Apache Spark K8s Operator](https://hub.docker.com/r/apache/spark-kubernetes-operator) and [Apache Spark Connect for Swift](https://hub.docker.com/r/apache/spark-connect-swift).
 
 ## About this repository
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to recommend `apache/*` images from Apache Spark 4.2.0.

### Why are the changes needed?

The Apache Spark (apache/spark) project has been growing rapidly in many ways. Looking at our subprojects, the Apache Spark K8s Operator(apache/spark-kubernetes-operator) has had 9 releases, and the Apache Spark Connect Swift Client (apache/spark-connect-swift) has had 6 releases.

Like GitHub repositories, we had better maintain architectural uniformity across Apache Spark projects in docker images:
- https://hub.docker.com/r/apache/spark
- https://hub.docker.com/r/apache/spark-kubernetes-operator
- https://hub.docker.com/r/apache/spark-connect-swift

### Does this PR introduce _any_ user-facing change?

No behavior change. This is only a documentation change.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.