### PR TITLE
[SPARK-57533] Move `merge_spark_docker_pr.py` to `dev` directory

### DIFF
--- a/dev/merge_spark_docker_pr.py
+++ b/dev/merge_spark_docker_pr.py
@@ -19,7 +19,7 @@
 
 # Utility for creating well-formed pull request merges and pushing them to Apache
 # Spark.
-#   usage: ./merge_spark_docker_pr.py    (see config env vars below)
+#   usage: ./dev/merge_spark_docker_pr.py    (see config env vars below)
 #
 # This utility assumes you already have a local Spark git folder and that you
 # have added remotes corresponding to both (i) the github apache Spark


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR moves `merge_spark_docker_pr.py` from the repository root into the `dev` directory.

### Why are the changes needed?

To keep the maintainer scripts in one place. `dev` already holds the related scripts (`create_spark_jira.py`, `create_jira_and_branch.py`, `spark_jira_utils.py`), and the script's own message already refers to its path as `dev/merge_spark_docker_pr.py`.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review because this is a move of file.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8)