### PR TITLE
[SPARK-57534] Add `Apache Spark K8s Operator` to awesome-spark-docker.md

### DIFF
--- a/awesome-spark-docker.md
+++ b/awesome-spark-docker.md
@@ -1,5 +1,6 @@
 A curated list of awesome Apache Spark Docker resources.
 
+- [Apache Spark K8s Operator](https://apache.github.io/spark-kubernetes-operator/) - A subproject of Apache Spark and aims to extend K8s resource manager to manage Apache Spark applications and clusters via Operator Pattern.
 - [jupyter/docker-stacks/pyspark-notebook](https://github.com/jupyter/docker-stacks/tree/main/images/pyspark-notebook) - PySpark with Jupyter Notebook.
 - [big-data-europe/docker-spark](https://github.com/big-data-europe/docker-spark) - The standalone cluster and spark applications related Dockerfiles.
 - [openeuler/spark](https://github.com/openeuler-mirror/openeuler-docker-images/tree/master/Bigdata/spark) - Dockerfile reference for dnf/yum based OS.


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `Apache Spark K8s Operator` to awesome-spark-docker.md.

### Why are the changes needed?

Apache Spark K8s Operator is almost ready for 1.0.0. We had better recommend it.
- https://apache.github.io/spark-kubernetes-operator/
  - [0.9.0 (2026-05-14)](https://github.com/apache/spark-kubernetes-operator/releases/tag/0.9.0)
  - [0.8.0 (2026-03-16)](https://github.com/apache/spark-kubernetes-operator/releases/tag/0.8.0)
  - [0.7.0 (2026-01-15)](https://github.com/apache/spark-kubernetes-operator/releases/tag/0.7.0)
  - [0.6.0 (2025-11-07)](https://github.com/apache/spark-kubernetes-operator/releases/tag/0.6.0)
  - [0.5.0 (2025-10-02)](https://github.com/apache/spark-kubernetes-operator/releases/tag/0.5.0)
  - [0.4.0 (2025-07-03)](https://github.com/apache/spark-kubernetes-operator/releases/tag/0.4.0)
  - [0.3.0 (2025-06-04)](https://github.com/apache/spark-kubernetes-operator/releases/tag/0.3.0)
  - [0.2.0 (2025-05-20)](https://github.com/apache/spark-kubernetes-operator/releases/tag/0.2.0)
  - [0.1.0 (2025-05-08)](https://github.com/apache/spark-kubernetes-operator/releases/tag/v0.1.0)

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review.

- https://github.com/dongjoon-hyun/spark-docker/blob/SPARK-57534/awesome-spark-docker.md

<img width="1138" height="642" alt="Screenshot 2026-06-18 at 09 50 03" src="https://github.com/user-attachments/assets/ea155326-f377-4038-8b50-c83da53f1427" />

### Was this patch authored or co-authored using generative AI tooling?

No.