### PR TITLE
[SPARK-57701] Install `libjemalloc2` in `Dockerfile.template`

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -23,7 +23,7 @@ RUN groupadd --system --gid=${spark_uid} spark && \
 
 RUN set -ex; \
     apt-get update; \
-    apt-get install -y gnupg2 wget bash tini libc6 libpam-modules krb5-user libnss3 procps net-tools gosu libnss-wrapper; \
+    apt-get install -y gnupg2 wget bash tini libc6 libpam-modules krb5-user libnss3 procps net-tools gosu libnss-wrapper libjemalloc2; \
     mkdir -p /opt/spark; \
     mkdir /opt/spark/python; \
     mkdir -p /opt/spark/examples; \


### PR DESCRIPTION
### What changes were proposed in this pull request?

Like Apache Spark main repository, this PR aims to install `libjemalloc2` in `Dockerfile.template` while the default allocator is unchanged

- https://github.com/apache/spark/pull/56782

### Why are the changes needed?


[jemalloc](http://jemalloc.net) reduces native/off-heap memory fragmentation, especially `off-heap`, `PySpark`, `Apache Arrow`, and `Spark-accellerator`  use-cases. Shipping the package lets operators enable it with one env var instead of building a custom image, with no regression for anyone else.

### Does this PR introduce _any_ user-facing change?

No behavior change because the default allocator is unchanged; the image just additionally ships `libjemalloc2`.

```
$ ls -al /usr/lib/aarch64-linux-gnu/libjemalloc.so.2
-rw-r--r-- 1 root root 527176 Apr 18  2024 /usr/lib/aarch64-linux-gnu/libjemalloc.so.2
```

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.8